### PR TITLE
Fix CVE-2022-41946

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -141,7 +141,7 @@ ext {
   junitJupiterVersion = '5.8.1'
   junitVintageVersion = '5.7.0'
   log4jVersion = '2.17.1'
-  postgresqlVersion = '42.4.1'
+  postgresqlVersion = '42.5.1'
   reformLogging= '5.1.9'
   restAssuredVersion = '4.3.0!!'
   springBootVersion = '2.7.4'
@@ -163,7 +163,6 @@ ext['guava.version'] = '30.0-jre'
 ext['apache.poi.version'] = '4.1.0'
 ext['snakeyaml.version'] = '1.33'
 ext['spring-security.version'] = '5.7.4'
-ext['postgresql.version'] = '42.2.16'
 ext['hibernate-validator.version'] = '6.0.20.Final'
 
 dependencyManagement {
@@ -234,10 +233,10 @@ allprojects {
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-data-jpa'
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-security'
     implementation group: 'org.flywaydb', name: 'flyway-core', version: '9.5.0'
-    implementation group: 'org.postgresql', name: 'postgresql', version: '42.5.0'
+    implementation group: 'org.postgresql', name: 'postgresql', version: postgresqlVersion
     implementation group: 'io.rest-assured', name: 'rest-assured'
 
-    testImplementation group: 'org.postgresql', name: 'postgresql', version: '42.5.0'
+    testImplementation group: 'org.postgresql', name: 'postgresql', version: postgresqlVersion
     testImplementation group: 'org.testcontainers', name: 'postgresql', version: '1.17.5'
 
     testImplementation "io.rest-assured:xml-path:${restAssuredVersion}"
@@ -351,7 +350,7 @@ subprojects { subproject ->
     implementation group: 'org.flywaydb', name: 'flyway-core', version: '9.5.0'
     implementation group: 'org.flywaydb', name: 'flyway-core', version: '6.5.7'
 
-    implementation group: 'org.postgresql', name: 'postgresql', version: '42.5.0'
+    implementation group: 'org.postgresql', name: 'postgresql', version: postgresqlVersion
 
     implementation group: 'org.springframework.security', name: 'spring-security-web'
     implementation group: 'org.springframework.security', name: 'spring-security-config'
@@ -364,10 +363,8 @@ subprojects { subproject ->
     implementation group: 'org.springframework', name: 'spring-jms', version: '5.3.23'
 
 
-    testImplementation group: 'org.postgresql', name: 'postgresql', version: '42.5.0'
-    testImplementation group: 'org.testcontainers', name: 'postgresql', version: '1.17.5'
     testImplementation group: 'org.postgresql', name: 'postgresql', version: postgresqlVersion
-    testImplementation group: 'org.testcontainers', name: 'postgresql', version: '1.17.2'
+    testImplementation group: 'org.testcontainers', name: 'postgresql', version: '1.17.5'
     testImplementation group: 'org.hamcrest', name: 'hamcrest-core', version: hamcrestVersion
     testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: hamcrestVersion
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: junitJupiterVersion

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -20,7 +20,6 @@
       CVE-2020-5408
       CVE-2022-31690
       CVE-2022-31692
-      CVE-2022-41946
       CVE-2022-42252
     </notes>
     <cve>CVE-2022-38752</cve>
@@ -28,7 +27,6 @@
     <cve>CVE-2020-5408</cve>
     <cve>CVE-2022-31690</cve>
     <cve>CVE-2022-31692</cve>
-    <cve>CVE-2022-41946</cve>
     <cve>CVE-2022-42252</cve>
   </suppress>
   <!--End of temporary suppression section -->


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
Updated postgresql version to 42.5.1 in build.gradle to resolve CVE-2022-41946.  Took opportunity to replace hardcoded postgresql versions with reference to postgresqlVersion variable and remove duplicate/redundant org.postgresql and org.testcontainers testImplementation references.

Also removed postgresl.version ext declaration as dependency tree showed that the version it referenced wasn't being used.

Updated suppressions.xml to remove suppression for CVE-2022-41946.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
