### PR TITLE
SDT-25: Fix XSD validation unit tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -252,6 +252,12 @@ allprojects {
       exclude group: 'junit', module: 'junit'
       exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
     }
+    /*
+    Use actual implementation of xerces 2.12.2 instead of the one bundled with Java.  The version in openJDK contains
+    a bug in XMLSchemaValidator where cvc-complex-type.4 errors are reported twice.  The bug causes some XSD validation
+    tests to fail when running under openJDK 11.0.17 and above.  This dependency can be removed when the bug is fixed.
+    */
+    testImplementation group: 'xerces', name: 'xercesImpl', version: '2.12.2'
   }
 
   configurations.all {
@@ -402,7 +408,12 @@ subprojects { subproject ->
     testImplementation group: 'org.easymock', name: 'easymock', version: '5.0.1'
     testImplementation group: 'org.jdom', name: 'jdom2', version: '2.0.6.1'
     testImplementation group: 'org.dbunit', name: 'dbunit', version: '2.7.3'
-
+    /*
+    Use actual implementation of xerces 2.12.2 instead of the one bundled with Java.  The version in openJDK contains
+    a bug in XMLSchemaValidator where cvc-complex-type.4 errors are reported twice.  The bug causes some XSD validation
+    tests to fail when running under openJDK 11.0.17 and above.  This dependency can be removed when the bug is fixed.
+    */
+    testImplementation group: 'xerces', name: 'xercesImpl', version: '2.12.2'
   }
 
   sonarqube {

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -18,6 +18,7 @@
       CVE-2022-38752
       CVE-2015-3208
       CVE-2020-5408
+      CVE-2022-1471  https://github.com/google/security-research/security/advisories/GHSA-mjmj-j48q-9wg2 (SnakeYaml)
       CVE-2022-31690
       CVE-2022-31692
       CVE-2022-42252
@@ -25,6 +26,7 @@
     <cve>CVE-2022-38752</cve>
     <cve>CVE-2015-3208</cve>
     <cve>CVE-2020-5408</cve>
+    <cve>CVE-2022-1471</cve>
     <cve>CVE-2022-31690</cve>
     <cve>CVE-2022-31692</cve>
     <cve>CVE-2022-42252</cve>

--- a/producers-api/src/unit-test/resources/xml/validation/BulkRequestResponse/BulkSubmitRequestMandatoryMissingErrorMessages.txt
+++ b/producers-api/src/unit-test/resources/xml/validation/BulkRequestResponse/BulkSubmitRequestMandatoryMissingErrorMessages.txt
@@ -1,6 +1,4 @@
 cvc-complex-type.2.4.b: The content of element 'tns:header' is not complete. One of '{"http://ws.sdt.moj.gov.uk/2013/sdt/BulkRequestSchema":sdtCustomerId}' is expected.
 cvc-complex-type.4: Attribute 'requestType' must appear on element 'tns:request'.
-cvc-complex-type.4: Attribute 'requestType' must appear on element 'tns:request'.
-cvc-complex-type.4: Attribute 'requestId' must appear on element 'tns:request'.
 cvc-complex-type.4: Attribute 'requestId' must appear on element 'tns:request'.
 cvc-complex-type.2.4.b: The content of element 'tns:request' is not complete. One of '{"http://ws.sdt.moj.gov.uk/2013/sdt/BulkRequestSchema":mcolClaim, "http://ws.sdt.moj.gov.uk/2013/sdt/BulkRequestSchema":mcolJudgment, "http://ws.sdt.moj.gov.uk/2013/sdt/BulkRequestSchema":mcolClaimStatusUpdate, "http://ws.sdt.moj.gov.uk/2013/sdt/BulkRequestSchema":mcolWarrant, "http://ws.sdt.moj.gov.uk/2013/sdt/BulkRequestSchema":mcolJudgmentWarrant, "http://ws.sdt.moj.gov.uk/2013/sdt/BulkRequestSchema":mcolSetAside, "http://ws.sdt.moj.gov.uk/2013/sdt/BulkRequestSchema":mcolBreathingSpace}' is expected.

--- a/producers-api/src/unit-test/resources/xml/validation/SubmitQueryRequestResponse/SubmitQueryRequestMandatoryMissingErrorMessages.txt
+++ b/producers-api/src/unit-test/resources/xml/validation/SubmitQueryRequestResponse/SubmitQueryRequestMandatoryMissingErrorMessages.txt
@@ -1,4 +1,3 @@
 cvc-complex-type.2.4.b: The content of element 'tns:header' is not complete. One of '{"http://ws.sdt.moj.gov.uk/2013/sdt/SubmitQueryRequestSchema":sdtCustomerId}' is expected.
 cvc-complex-type.2.4.b: The content of element 'tns:criterion' is not complete. One of '{"http://ws.sdt.moj.gov.uk/2013/sdt/SubmitQueryRequestSchema":mcolDefenceCriteria}' is expected.
 cvc-complex-type.4: Attribute 'criteriaType' must appear on element 'tns:criterion'.
-cvc-complex-type.4: Attribute 'criteriaType' must appear on element 'tns:criterion'.


### PR DESCRIPTION
### JIRA link (if applicable) ###
SDT-25 (https://tools.hmcts.net/jira/browse/SDT-25)


### Change description ###
A bug in the openJDK implementation of xerces 2.12.2 causes cvc-complex-type.4 errors to be reported twice.  This causes two of the XSD validation unit tests to fail when using openJDK 11.0.17 or above.  To fix this added a dependency for the actual version of xerces 2.12.2 which doesn't have the bug in it.

Removed duplicate cvc-complex-type.4 errors from BulkSubmitRequestMandatoryMissingErrorMessages.txt and SubmitQueryRequestMandatoryMissingErrorMessages.txt.

Added suppression for CVE-2022-1471 which is flagged by Template CI dependency check stage.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
