### PR TITLE
Fix CVE-2022-31690 and CVE-2022-31692

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -162,7 +162,7 @@ ext['jackson.version'] = '2.14.0-rc1'
 ext['guava.version'] = '30.0-jre'
 ext['apache.poi.version'] = '4.1.0'
 ext['snakeyaml.version'] = '1.33'
-ext['spring-security.version'] = '5.7.4'
+ext['spring-security.version'] = '5.7.5'
 ext['hibernate-validator.version'] = '6.0.20.Final'
 
 dependencyManagement {

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -19,17 +19,12 @@
       CVE-2015-3208
       CVE-2020-5408
       CVE-2022-1471  https://github.com/google/security-research/security/advisories/GHSA-mjmj-j48q-9wg2 (SnakeYaml)
-      CVE-2022-31690
-      CVE-2022-31692
     </notes>
     <cve>CVE-2022-38752</cve>
     <cve>CVE-2015-3208</cve>
     <cve>CVE-2020-5408</cve>
     <cve>CVE-2022-1471</cve>
-    <cve>CVE-2022-31690</cve>
-    <cve>CVE-2022-31692</cve>
   </suppress>
   <!--End of temporary suppression section -->
-
 
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
Updated spring-security version in build.gradle to 5.7.5 to fix CVE-2022-31690 and CVE-2022-31692.  Removed corresponding suppressions from suppressions.xml.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
