### PR TITLE
Updated workflow action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
         with:
           distribution: 'temurin' # See 'Supported distributions' for available options
           java-version: '11'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin' # See 'Supported distributions' for available options
-          java-version: '11'
+          java-version: '17'
           cache: 'gradle'
       - name: Build
         run: ./gradlew check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3.9.0
         with:
           distribution: 'temurin' # See 'Supported distributions' for available options
           java-version: '11'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v2
         with:
           distribution: 'temurin' # See 'Supported distributions' for available options
-          java-version: '17'
+          java-version: '11'
           cache: 'gradle'
       - name: Build
         run: ./gradlew check


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
Updated the versions of the actions in the Template CI workflow to resolve warnings about the use of deprecated features.  This is the same change that was made to the workflow in the spring-boot-template repository in https://github.com/hmcts/spring-boot-template/pull/411.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
