### PR TITLE
SDT-25: Ensure xercesImpl is used

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -236,6 +236,12 @@ allprojects {
     implementation group: 'org.flywaydb', name: 'flyway-core', version: '9.5.0'
     implementation group: 'org.postgresql', name: 'postgresql', version: postgresqlVersion
     implementation group: 'io.rest-assured', name: 'rest-assured'
+    /*
+    Use actual implementation of xerces 2.12.2 instead of the one bundled with Java.  The version in openJDK contains
+    a bug in XMLSchemaValidator where cvc-complex-type.4 errors are reported twice. This dependency can be removed
+    when the bug is fixed.
+    */
+    implementation group: 'xerces', name: 'xercesImpl', version: '2.12.2'
 
     testImplementation group: 'org.postgresql', name: 'postgresql', version: postgresqlVersion
     testImplementation group: 'org.testcontainers', name: 'postgresql', version: '1.17.5'
@@ -369,7 +375,12 @@ subprojects { subproject ->
     }
 
     implementation group: 'org.springframework', name: 'spring-jms', version: '5.3.23'
-
+    /*
+    Use actual implementation of xerces 2.12.2 instead of the one bundled with Java.  The version in openJDK contains
+    a bug in XMLSchemaValidator where cvc-complex-type.4 errors are reported twice.  This dependency can be removed
+    when the bug is fixed.
+    */
+    implementation group: 'xerces', name: 'xercesImpl', version: '2.12.2'
 
     testImplementation group: 'org.postgresql', name: 'postgresql', version: postgresqlVersion
     testImplementation group: 'org.testcontainers', name: 'postgresql', version: '1.17.5'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -21,6 +21,7 @@
       CVE-2021-37533 https://nvd.nist.gov/vuln/detail/CVE-2021-37533 (apache commons)
       CVE-2022-1471  https://github.com/google/security-research/security/advisories/GHSA-mjmj-j48q-9wg2 (SnakeYaml)
       CVE-2022-40152 https://github.com/advisories/GHSA-3f7h-mf4q-vrm4 (woodstox-core - may be false positive)
+      CVE-2022-41915 https://github.com/netty/netty/security/advisories/GHSA-hh82-3pmq-7frp (netty-codec)
     </notes>
     <cve>CVE-2015-3208</cve>
     <cve>CVE-2017-10355</cve>
@@ -28,6 +29,7 @@
     <cve>CVE-2021-37533</cve>
     <cve>CVE-2022-1471</cve>
     <cve>CVE-2022-40152</cve>
+    <cve>CVE-2022-41915</cve>
   </suppress>
   <!--End of temporary suppression section -->
 

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -16,11 +16,13 @@
   <suppress>
     <notes>Temporary Suppression
       CVE-2015-3208
+      CVE-2017-10355 https://github.com/jeremylong/DependencyCheck/issues/4614 (xercesImpl - may be false positive)
       CVE-2020-5408
       CVE-2022-1471  https://github.com/google/security-research/security/advisories/GHSA-mjmj-j48q-9wg2 (SnakeYaml)
       CVE-2022-40152 https://github.com/advisories/GHSA-3f7h-mf4q-vrm4 (woodstox-core - may be false positive)
     </notes>
     <cve>CVE-2015-3208</cve>
+    <cve>CVE-2017-10355</cve>
     <cve>CVE-2020-5408</cve>
     <cve>CVE-2022-1471</cve>
     <cve>CVE-2022-40152</cve>

--- a/utils/src/unit-test/java/uk/gov/moj/sdt/utils/AbstractSdtXmlTestBase.java
+++ b/utils/src/unit-test/java/uk/gov/moj/sdt/utils/AbstractSdtXmlTestBase.java
@@ -95,6 +95,11 @@ public abstract class AbstractSdtXmlTestBase extends AbstractSdtGoodFileTestBase
     public static final String ERROR_FILE_SUFFIX = "ErrorMessages.txt";
 
     /**
+     * Fully qualified name of class that implements SAXParserFactory.
+     */
+    private static final String SAX_PARSER_FACTORY_IMPL_CLASS = "org.apache.xerces.jaxp.SAXParserFactoryImpl";
+
+    /**
      * Logging object.
      */
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractSdtXmlTestBase.class);
@@ -206,7 +211,7 @@ public abstract class AbstractSdtXmlTestBase extends AbstractSdtGoodFileTestBase
 
         // Create SAX parser factory; turn on validation and check all name
         // spaces; use given schema for validation.
-        final SAXParserFactory saxFactory = SAXParserFactory.newInstance();
+        final SAXParserFactory saxFactory = SAXParserFactory.newInstance(SAX_PARSER_FACTORY_IMPL_CLASS, null);
         // saxFactory.setValidating (true);
         saxFactory.setNamespaceAware(true);
         saxFactory.setSchema(schema);

--- a/validators/src/main/java/uk/gov/moj/sdt/validators/XmlValidator.java
+++ b/validators/src/main/java/uk/gov/moj/sdt/validators/XmlValidator.java
@@ -67,6 +67,11 @@ public class XmlValidator implements IXmlValidator {
     private static final Logger LOGGER = LoggerFactory.getLogger(XmlValidator.class);
 
     /**
+     * Fully qualified name of class that implements SAXParserFactory.
+     */
+    private static final String SAX_PARSER_FACTORY_IMPL_CLASS = "org.apache.xerces.jaxp.SAXParserFactoryImpl";
+
+    /**
      * The xml that requires validation.
      */
     private String xmlToValidate;
@@ -135,7 +140,7 @@ public class XmlValidator implements IXmlValidator {
 
         // Create SAX parser factory; turn on validation and check all name
         // spaces; use given schema for validation.
-        final SAXParserFactory saxFactory = SAXParserFactory.newInstance();
+        final SAXParserFactory saxFactory = SAXParserFactory.newInstance(SAX_PARSER_FACTORY_IMPL_CLASS, null);
         // saxFactory.setValidating (true);
         saxFactory.setNamespaceAware(true);
         saxFactory.setSchema(schema);


### PR DESCRIPTION
### JIRA link (if applicable) ###
SDT-25 (https://tools.hmcts.net/jira/browse/SDT-25)


### Change description ###
Explicitly set class that implements SaxParserFactory to the xercesImpl SaxParserFactoryImpl class.  This should ensure that xerces implementation is always used over default Java implementation.

Updated suppressions.xml to suppress CVE-2017-10355.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
