### PR TITLE
Corrected sonar project properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -531,8 +531,8 @@ subprojects { subproject ->
 
 sonarqube {
   properties {
-    property "sonar.projectName", "Reform :: civil-sdt-gateway"
-    property "sonar.projectKey", "uk.gov.hmcts.reform:civil-sdt-gateway"
+    property "sonar.projectName", "Reform :: civil-sdt"
+    property "sonar.projectKey", "uk.gov.hmcts.reform:civil-sdt"
     property "sonar.coverage.jacoco.xmlReportPaths", "${jacocoTestReport.reports.xml.destination.path}"
   }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
Changed values of sonar.projectName and sonar.projectKey properties in build.gradle to reference civil-sdt rather than civil-sdt-gateway.  This should ensure that the civil-sdt sonar reports are associated with the correct project in sonarcloud.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
