### PR TITLE
Update Helm java chart version to 4.0.9

### DIFF
--- a/charts/civil-sdt/Chart.yaml
+++ b/charts/civil-sdt/Chart.yaml
@@ -3,12 +3,12 @@ appVersion: "1.0"
 description: A Helm chart for civil-sdt app
 name: civil-sdt
 home: https://github.com/hmcts/civil-sdt
-version: 0.0.3
+version: 0.0.4
 maintainers:
   - name: HMCTS SDT team
 dependencies:
   - name: java
-    version: 4.0.4
+    version: 4.0.9
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
   - name: servicebus
     version: 0.3.0


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A/


### Change description ###
Updated Helm java chart version to 4.0.9. This is required as older versions aren't supported in latest AKS release (1.25).


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
