### PR TITLE
Updated DependencyCheck version to 8.0.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,9 +7,9 @@ plugins {
   id 'java'
   id "io.freefair.lombok" version "6.5.1"
   id 'io.spring.dependency-management' version '1.1.0'
-  id 'com.github.ben-manes.versions' version '0.42.0'
+  id 'com.github.ben-manes.versions' version '0.44.0'
   id 'org.springframework.boot' version '2.7.7'
-  id 'org.owasp.dependencycheck' version '6.5.3'
+  id 'org.owasp.dependencycheck' version '8.0.2'
   id 'com.github.kt3k.coveralls' version '2.8.2'
   id 'com.github.spacialcircumstances.gradle-cucumber-reporting' version '0.1.23'
   id 'org.sonarqube' version '3.4.0.2513'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -2,37 +2,17 @@
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
 
   <!--Please add all the false positives under the below section-->
+  <!--
   <suppress>
     <notes>False Positives
-      CVE-2016-1000027
-      CVE-2018-1258
-      CVE-2020-7712
-      CVE-2020-10663
     </notes>
-    <cve>CVE-2016-1000027</cve>
-    <cve>CVE-2018-1258</cve>
-    <cve>CVE-2020-7712</cve>
-    <cve>CVE-2020-10663</cve>
   </suppress>
+  -->
   <!--End of false positives section -->
 
   <!--Please add all the temporary suppression under the below section-->
   <suppress>
     <notes>Temporary Suppression
-      CVE-2015-3208  https://nvd.nist.gov/vuln/detail/CVE-2015-3208
-      CVE-2017-10355 https://github.com/jeremylong/DependencyCheck/issues/4614 (xercesImpl - may be false positive)
-      CVE-2020-5408  https://nvd.nist.gov/vuln/detail/CVE-2020-5408
-      CVE-2020-5412  https://nvd.nist.gov/vuln/detail/CVE-2020-5412
-      CVE-2021-4235  https://nvd.nist.gov/vuln/detail/CVE-2021-4235
-      CVE-2021-4277  https://nvd.nist.gov/vuln/detail/CVE-2021-4277
-      CVE-2021-37533 https://nvd.nist.gov/vuln/detail/CVE-2021-37533 (apache commons)
-      CVE-2022-1471  https://github.com/google/security-research/security/advisories/GHSA-mjmj-j48q-9wg2 (SnakeYaml)
-      CVE-2022-3064  https://nvd.nist.gov/vuln/detail/CVE-2022-30664
-      CVE-2022-22976 https://nvd.nist.gov/vuln/detail/CVE-2022-22976
-      CVE-2022-38752 https://nvd.nist.gov/vuln/detail/CVE-2022-38752
-      CVE-2022-40152 https://github.com/advisories/GHSA-3f7h-mf4q-vrm4 (woodstox-core - may be false positive)
-      CVE-2022-41881 https://nvd.nist.gov/vuln/detail/CVE-2022-41881
-      CVE-2022-41915 https://github.com/netty/netty/security/advisories/GHSA-hh82-3pmq-7frp (netty-codec)
       CVE-2022-46363
       CVE-2022-46364
       CVE-2020-8908
@@ -40,20 +20,6 @@
       CVE-2016-3094
       CVE-2022-45143
     </notes>
-    <cve>CVE-2015-3208</cve>
-    <cve>CVE-2017-10355</cve>
-    <cve>CVE-2020-5408</cve>
-    <cve>CVE-2020-5412</cve>
-    <cve>CVE-2021-4235</cve>
-    <cve>CVE-2021-4277</cve>
-    <cve>CVE-2021-37533</cve>
-    <cve>CVE-2022-1471</cve>
-    <cve>CVE-2022-3064</cve>
-    <cve>CVE-2022-22976</cve>
-    <cve>CVE-2022-38752</cve>
-    <cve>CVE-2022-40152</cve>
-    <cve>CVE-2022-41881</cve>
-    <cve>CVE-2022-41915</cve>
     <cve>CVE-2022-46363</cve>
     <cve>CVE-2022-46364</cve>
     <cve>CVE-2020-8908</cve>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -38,10 +38,6 @@
       CVE-2020-8908
       CVE-2018-10237
       CVE-2016-3094
-      CVE-2022-41881
-      CVE-2021-4277
-      CVE-2021-4235
-      CVE-2022-3064
       CVE-2022-45143
     </notes>
     <cve>CVE-2015-3208</cve>
@@ -63,10 +59,6 @@
     <cve>CVE-2020-8908</cve>
     <cve>CVE-2018-10237</cve>
     <cve>CVE-2016-3094</cve>
-    <cve>CVE-2022-41881</cve>
-    <cve>CVE-2021-4277</cve>
-    <cve>CVE-2021-4235</cve>
-    <cve>CVE-2022-3064</cve>
     <cve>CVE-2022-45143</cve>
   </suppress>
   <!--End of temporary suppression section -->


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
Updated DependencyCheck version to 8.0.2.  This is needed to fit in with a change to be made to the common pipeline to utilise the global suppressions file (see https://jeremylong.github.io/DependencyCheck/suppressions/publishedSuppressions.xml).

In addition, updated versions plugin to latest version (0.44.0) and removed duplicate suppressions from suppressions.xml.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
