### PR TITLE
SDT-99 Update existing Submit Query workflow

### DIFF
--- a/consumers/src/main/java/uk/gov/moj/sdt/cmc/consumers/api/CmcApi.java
+++ b/consumers/src/main/java/uk/gov/moj/sdt/cmc/consumers/api/CmcApi.java
@@ -1,6 +1,7 @@
 package uk.gov.moj.sdt.cmc.consumers.api;
 
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -20,5 +21,14 @@ public interface CmcApi {
         @RequestHeader(AUTHORIZATION) String authorisation,
         @RequestHeader("ServiceAuthorzation") String serviceAuthorization,
         @RequestBody IIndividualRequest individualRequest
+    );
+
+    @GetMapping("/claimDefences")
+    Object claimDefences(
+            @RequestHeader(AUTHORIZATION) String authorisation,
+            @RequestHeader("ServiceAuthorzation") String serviceAuthorization,
+            @RequestHeader("idAmId") String idAmId,
+            @RequestHeader("fromDateTime") String fromDateTime,
+            @RequestHeader("toDateTime") String toDateTime
     );
 }

--- a/consumers/src/main/java/uk/gov/moj/sdt/cmc/consumers/api/CmcApiFallback.java
+++ b/consumers/src/main/java/uk/gov/moj/sdt/cmc/consumers/api/CmcApiFallback.java
@@ -9,8 +9,12 @@ public class CmcApiFallback implements CmcApi {
 
     private IBreathingSpace breathingSpace;
 
-    public CmcApiFallback(@Qualifier("MockBreathingSpaceService") IBreathingSpace breathingSpace) {
+    private IClaimDefences claimDefences;
+
+    public CmcApiFallback(@Qualifier("MockBreathingSpaceService") IBreathingSpace breathingSpace,
+                          @Qualifier("MockClaimDefencesService") IClaimDefences claimDefences) {
         this.breathingSpace = breathingSpace;
+        this.claimDefences = claimDefences;
     }
 
     @Override
@@ -18,5 +22,14 @@ public class CmcApiFallback implements CmcApi {
                                  String serviceAuthorization,
                                  IIndividualRequest individualRequest) {
         return breathingSpace.breathingSpace(individualRequest);
+    }
+
+    @Override
+    public Object claimDefences(String authorisation,
+                                String serviceAuthorization,
+                                String idAmId,
+                                String fromDateTime,
+                                String toDateTime) {
+        return claimDefences.claimDefences(idAmId, fromDateTime, toDateTime);
     }
 }

--- a/consumers/src/main/java/uk/gov/moj/sdt/cmc/consumers/api/IClaimDefences.java
+++ b/consumers/src/main/java/uk/gov/moj/sdt/cmc/consumers/api/IClaimDefences.java
@@ -1,0 +1,6 @@
+package uk.gov.moj.sdt.cmc.consumers.api;
+
+public interface IClaimDefences {
+
+    Object claimDefences(String idAmId, String fromDateTime, String toDateTime);
+}

--- a/consumers/src/main/java/uk/gov/moj/sdt/cmc/consumers/client/impl/ClaimDefencesService.java
+++ b/consumers/src/main/java/uk/gov/moj/sdt/cmc/consumers/client/impl/ClaimDefencesService.java
@@ -1,0 +1,17 @@
+package uk.gov.moj.sdt.cmc.consumers.client.impl;
+
+import org.springframework.stereotype.Service;
+import uk.gov.moj.sdt.cmc.consumers.api.CmcApi;
+import uk.gov.moj.sdt.cmc.consumers.api.IClaimDefences;
+
+
+@Service("ClaimDefencesService")
+public class ClaimDefencesService implements IClaimDefences {
+
+    private CmcApi cmcApi;
+
+    @Override
+    public Object claimDefences(String idAmId, String fromDateTime, String toDateTime) {
+        return cmcApi.claimDefences("", "", idAmId, fromDateTime, toDateTime);
+    }
+}

--- a/consumers/src/main/java/uk/gov/moj/sdt/cmc/consumers/client/impl/ClaimDefencesService.java
+++ b/consumers/src/main/java/uk/gov/moj/sdt/cmc/consumers/client/impl/ClaimDefencesService.java
@@ -1,5 +1,6 @@
 package uk.gov.moj.sdt.cmc.consumers.client.impl;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.moj.sdt.cmc.consumers.api.CmcApi;
 import uk.gov.moj.sdt.cmc.consumers.api.IClaimDefences;
@@ -9,6 +10,11 @@ import uk.gov.moj.sdt.cmc.consumers.api.IClaimDefences;
 public class ClaimDefencesService implements IClaimDefences {
 
     private CmcApi cmcApi;
+
+    @Autowired
+    public ClaimDefencesService(CmcApi cmcApi) {
+        this.cmcApi = cmcApi;
+    }
 
     @Override
     public Object claimDefences(String idAmId, String fromDateTime, String toDateTime) {

--- a/consumers/src/main/java/uk/gov/moj/sdt/cmc/consumers/client/mock/MockClaimDefencesService.java
+++ b/consumers/src/main/java/uk/gov/moj/sdt/cmc/consumers/client/mock/MockClaimDefencesService.java
@@ -1,0 +1,13 @@
+package uk.gov.moj.sdt.cmc.consumers.client.mock;
+
+import org.springframework.stereotype.Service;
+import uk.gov.moj.sdt.cmc.consumers.api.IClaimDefences;
+
+@Service("MockClaimDefencesService")
+public class MockClaimDefencesService implements IClaimDefences {
+
+    @Override
+    public Object claimDefences(String idAmId, String fromDateTime, String toDateTime) {
+        return null;
+    }
+}

--- a/consumers/src/unit-test/java/uk/gov/moj/sdt/cmc/consumers/client/impl/ClaimDefenceServiceTest.java
+++ b/consumers/src/unit-test/java/uk/gov/moj/sdt/cmc/consumers/client/impl/ClaimDefenceServiceTest.java
@@ -1,0 +1,45 @@
+package uk.gov.moj.sdt.cmc.consumers.client.impl;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.moj.sdt.cmc.consumers.api.CmcApi;
+import uk.gov.moj.sdt.utils.AbstractSdtUnitTestBase;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class ClaimDefenceServiceTest extends AbstractSdtUnitTestBase {
+
+    @Mock
+    private CmcApi cmcApi;
+
+    private ClaimDefencesService claimDefencesService;
+
+    private final Object OBJECT = new Object();
+
+    @BeforeEach
+    @Override
+    public void setUp() {
+        claimDefencesService = new ClaimDefencesService(cmcApi);
+        when(cmcApi.claimDefences(anyString(), anyString(), anyString(), anyString(), anyString()))
+                .thenReturn(OBJECT);
+    }
+
+    @Test
+    void getClient() {
+        String idAmId = "";
+        String fromDateTime = "";
+        String toDateTime = "";
+
+        Object returnValue = claimDefencesService.claimDefences(idAmId, fromDateTime, toDateTime);
+        assertNotNull(returnValue);
+        assertEquals(OBJECT, returnValue);
+    }
+
+}

--- a/consumers/src/unit-test/java/uk/gov/moj/sdt/cmc/consumers/client/mock/MockClaimDefencesServiceTest.java
+++ b/consumers/src/unit-test/java/uk/gov/moj/sdt/cmc/consumers/client/mock/MockClaimDefencesServiceTest.java
@@ -9,7 +9,7 @@ import uk.gov.moj.sdt.utils.AbstractSdtUnitTestBase;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 @ExtendWith(MockitoExtension.class)
-public class MockClaimDefencesServiceTest extends AbstractSdtUnitTestBase {
+class MockClaimDefencesServiceTest extends AbstractSdtUnitTestBase {
 
     private MockClaimDefencesService mockClaimDefencesService;
 

--- a/consumers/src/unit-test/java/uk/gov/moj/sdt/cmc/consumers/client/mock/MockClaimDefencesServiceTest.java
+++ b/consumers/src/unit-test/java/uk/gov/moj/sdt/cmc/consumers/client/mock/MockClaimDefencesServiceTest.java
@@ -1,0 +1,31 @@
+package uk.gov.moj.sdt.cmc.consumers.client.mock;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.moj.sdt.utils.AbstractSdtUnitTestBase;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@ExtendWith(MockitoExtension.class)
+public class MockClaimDefencesServiceTest extends AbstractSdtUnitTestBase {
+
+    private MockClaimDefencesService mockClaimDefencesService;
+
+    @BeforeEach
+    @Override
+    public void setUp() {
+        mockClaimDefencesService = new MockClaimDefencesService();
+    }
+
+    @Test
+    void getClient() {
+        final String idAmId = "";
+        final String fromDateTime = "";
+        final String toDateTime = "";
+        Object returnValue = mockClaimDefencesService.claimDefences(idAmId, fromDateTime, toDateTime);
+        assertNull(returnValue);
+    }
+
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SDT-99

### Change description ###

Submit Query is one type of request that can be sent to SDT and then passed through to MCOL.

The following additional steps are carried out when processing each queued individual request:

If the request is for a claim that has a CCD case reference (as opposed to a CaseMan case reference) and it is for the submit query request, then the request is passed to the new endpoint with the contents of the XML request translated into the JSON equivalent and the response used to update the SDT database with the result:
Claim Defences (POST /[claimDefences](https://tools.hmcts.net/confluence/display/SDT/Claim+Defences+Query#ClaimDefencesQuery-/claimDefences))


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[*] No
```
