### PR TITLE
Suppress CVE-2022-40705 as a false positive

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -2,12 +2,12 @@
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
 
   <!--Please add all the false positives under the below section-->
-  <!--
   <suppress>
     <notes>False Positives
+      CVE-2022-40705 - see https://github.com/jeremylong/DependencyCheck/issues/5543
     </notes>
+    <cve>CVE-2022-40705</cve>
   </suppress>
-  -->
   <!--End of false positives section -->
 
   <!--Please add all the temporary suppression under the below section-->


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
Added CVE-2022-40705 to false positives section of suppressions.xml.  This can be removed when Dependency Check has been updated (see https://github.com/jeremylong/DependencyCheck/issues/5543).


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
