### PR TITLE
Remove redundant deployment_namespace Terraform var

### DIFF
--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -15,8 +15,6 @@ variable "env" {}
 
 variable "subscription" {}
 
-variable "deployment_namespace" {}
-
 variable "common_tags" {
   type = map(string)
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
Remove redundant deployment_namespace Terraform var from variables.tf


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
