### PR TITLE
Updated Terraform configuration

### DIFF
--- a/infrastructure/key-vault.tf
+++ b/infrastructure/key-vault.tf
@@ -1,5 +1,5 @@
 data "azurerm_key_vault" "civil_vault" {
-  name                = "civil-${var.env}"
+  name                = "civil-shared-${var.env}"
   resource_group_name = local.civil_shared_resource_group
 }
 

--- a/infrastructure/key-vault.tf
+++ b/infrastructure/key-vault.tf
@@ -1,7 +1,6 @@
-
 data "azurerm_key_vault" "civil_vault" {
   name                = "civil-${var.env}"
-  resource_group_name = azurerm_resource_group.rg.name
+  resource_group_name = local.civil_shared_resource_group
 }
 
 data "azurerm_key_vault" "s2s_vault" {
@@ -29,12 +28,4 @@ resource "azurerm_key_vault_secret" "api_gw_s2s_secret" {
   name         = "api-gateway-s2s-secret"
   value        = data.azurerm_key_vault_secret.api_gw_s2s_key.value
   key_vault_id = data.azurerm_key_vault.civil_vault.id
-}
-
-output "vaultName" {
-  value = data.azurerm_key_vault.civil_vault.name
-}
-
-output "vaultUri" {
-  value = data.azurerm_key_vault.civil_vault.vault_uri
 }

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -6,12 +6,5 @@ locals {
       "Destroy Me"   = var.destroy_me
     })
   ))
-}
-
-// Shared Resource Group
-resource "azurerm_resource_group" "rg" {
-  name     = "${var.product}-shared-${var.env}"
-  location = var.location
-
-  tags = local.tags
+  civil_shared_resource_group = "${var.product}-shared-${var.env}"
 }

--- a/infrastructure/output.tf
+++ b/infrastructure/output.tf
@@ -1,0 +1,17 @@
+output "vaultName" {
+  value = data.azurerm_key_vault.civil_vault.name
+}
+
+output "vaultUri" {
+  value = data.azurerm_key_vault.civil_vault.vault_uri
+}
+
+output "sb_primary_send_and_listen_connection_string" {
+  value     = module.servicebus-namespace.primary_send_and_listen_connection_string
+  sensitive = true
+}
+
+output "sb_primary_send_and_listen_shared_access_key" {
+  value     = module.servicebus-namespace.primary_send_and_listen_shared_access_key
+  sensitive = true
+}

--- a/infrastructure/service-bus.tf
+++ b/infrastructure/service-bus.tf
@@ -1,11 +1,10 @@
-
 module "servicebus-namespace" {
   providers = {
     azurerm.private_endpoint = azurerm.private_endpoint
   }
   source              = "git@github.com:hmcts/terraform-module-servicebus-namespace?ref=master"
   name                = "${var.product}-servicebus-${var.env}"
-  resource_group_name = azurerm_resource_group.rg.name
+  resource_group_name = local.civil_shared_resource_group
   location            = var.location
   env                 = var.env
   common_tags         = local.tags
@@ -17,20 +16,9 @@ module "servicebus-sdt-queue" {
   source              = "git@github.com:hmcts/terraform-module-servicebus-queue?ref=master"
   name                = "${var.product}-${var.component}-in-out-${var.env}"
   namespace_name      = module.servicebus-namespace.name
-  resource_group_name = azurerm_resource_group.rg.name
+  resource_group_name = local.civil_shared_resource_group
 
   depends_on = [module.servicebus-namespace]
-}
-
-
-output "sb_primary_send_and_listen_connection_string" {
-  value     = module.servicebus-namespace.primary_send_and_listen_connection_string
-  sensitive = true
-}
-
-output "sb_primary_send_and_listen_shared_access_key" {
-  value     = module.servicebus-namespace.primary_send_and_listen_shared_access_key
-  sensitive = true
 }
 
 resource "azurerm_key_vault_secret" "servicebus_primary_connection_string" {
@@ -44,4 +32,3 @@ resource "azurerm_key_vault_secret" "servicebus_primary_shared_access_key" {
   value        = module.servicebus-namespace.primary_send_and_listen_shared_access_key
   key_vault_id = data.azurerm_key_vault.civil_vault.id
 }
-

--- a/infrastructure/state.tf
+++ b/infrastructure/state.tf
@@ -1,5 +1,10 @@
 provider "azurerm" {
   features {}
+  subscription_id = var.aks_subscription_id
+}
+
+provider "azurerm" {
+  features {}
   skip_provider_registration = true
   alias                      = "private_endpoint"
   subscription_id            = var.aks_subscription_id

--- a/infrastructure/state.tf
+++ b/infrastructure/state.tf
@@ -1,6 +1,5 @@
 provider "azurerm" {
   features {}
-  subscription_id = var.aks_subscription_id
 }
 
 provider "azurerm" {

--- a/infrastructure/state.tf
+++ b/infrastructure/state.tf
@@ -1,9 +1,5 @@
 provider "azurerm" {
   features {}
-}
-
-provider "azurerm" {
-  features {}
   skip_provider_registration = true
   alias                      = "private_endpoint"
   subscription_id            = var.aks_subscription_id


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
- Removed civil-shared resource declaration from main.tf.  This is already being created in the civil-shared-infrastructure Terraform configuration.  Replaced it with a new local civil_shared_resource_group variable.
- Replaced references to shared resource group with civil_shared_resource_group variable in key-vault.tf and service-bus.tf.
- Moved output variables from key-vault.tf and service-bus.tf to output.tf.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
