### PR TITLE
Updated CVE suppressions

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -14,20 +14,16 @@
   <suppress>
     <notes>Temporary Suppression
       CVE-2016-3094
-      CVE-2018-10237
-      CVE-2020-8908
+      CVE-2022-1471
       CVE-2022-40152
-      CVE-2022-40705
       CVE-2022-45143
       CVE-2022-46363
       CVE-2022-46364
       CVE-2022-45688
     </notes>
     <cve>CVE-2016-3094</cve>
-    <cve>CVE-2018-10237</cve>
-    <cve>CVE-2020-8908</cve>
+    <cve>CVE-2022-1471</cve>
     <cve>CVE-2022-40152</cve>
-    <cve>CVE-2022-40705</cve>
     <cve>CVE-2022-45143</cve>
     <cve>CVE-2022-46363</cve>
     <cve>CVE-2022-46364</cve>


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
- Added suppression for CVE-2022-1471
- Removed suppressions for CVE-2018-10237, CVE-2020-8908 and CVE-2022-40705 as are no longer flagged.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
