### PR TITLE
SDT-113 - consumers, domain and producers now above 90% jacoco code coverage

### DIFF
--- a/consumers/src/main/java/uk/gov/moj/sdt/consumers/AbstractWsConsumer.java
+++ b/consumers/src/main/java/uk/gov/moj/sdt/consumers/AbstractWsConsumer.java
@@ -88,6 +88,9 @@ public abstract class AbstractWsConsumer {
                     targetApplicationCode, serviceType, webServiceEndPoint, connectionTimeOut, receiveTimeOut);
         }
 
+        String out = targetApplicationCode+ serviceType+ webServiceEndPoint+ connectionTimeOut+ receiveTimeOut;
+        System.out.println(out);
+
         final String clientCacheKey = targetApplicationCode + serviceType;
         ITargetAppInternalEndpointPortType client = null;
 

--- a/consumers/src/unit-test/java/uk/gov/moj/sdt/consumers/config/ConsumersConfigTest.java
+++ b/consumers/src/unit-test/java/uk/gov/moj/sdt/consumers/config/ConsumersConfigTest.java
@@ -1,0 +1,73 @@
+package uk.gov.moj.sdt.consumers.config;
+
+import org.apache.cxf.binding.soap.SoapMessage;
+import org.apache.cxf.phase.PhaseInterceptor;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.moj.sdt.interceptors.in.SdtUnmarshallInterceptor;
+import uk.gov.moj.sdt.interceptors.in.XmlInboundInterceptor;
+import uk.gov.moj.sdt.interceptors.out.CacheEndOutboundInterceptor;
+import uk.gov.moj.sdt.interceptors.out.CacheSetupOutboundInterceptor;
+import uk.gov.moj.sdt.interceptors.out.XmlOutboundInterceptor;
+import uk.gov.moj.sdt.ws._2013.sdt.targetappinternalendpoint.ITargetAppInternalEndpointPortType;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class ConsumersConfigTest {
+
+    @Spy
+    ConsumersConfig consumersConfig = new ConsumersConfig();
+
+    @Mock
+    XmlOutboundInterceptor xmlOutboundInterceptor;
+
+    @Mock
+    CacheSetupOutboundInterceptor cacheSetupOutboundInterceptor;
+
+    @Mock
+    CacheEndOutboundInterceptor performanceLoggerOutboundInterceptor;
+
+    @Mock
+    CacheEndOutboundInterceptor cacheEndOutboundInterceptor;
+
+    @Mock
+    PhaseInterceptor<SoapMessage> performanceLoggerInboundInterceptor;
+
+    @Mock
+    XmlInboundInterceptor xmlInboundInterceptor;
+
+    @Mock
+    SdtUnmarshallInterceptor sdtUnmarshallInterceptor;
+
+    @Test
+    void testCreateTargetAppInternalEndpointPortType() {
+        ITargetAppInternalEndpointPortType result =
+            consumersConfig.createTargetAppInternalEndpointPortType(
+                xmlOutboundInterceptor,
+                cacheSetupOutboundInterceptor,
+                performanceLoggerOutboundInterceptor,
+                cacheEndOutboundInterceptor,
+                performanceLoggerInboundInterceptor,
+                xmlInboundInterceptor,
+                sdtUnmarshallInterceptor
+            );
+
+        verify(consumersConfig).createTargetAppInternalEndpointPortType(
+            xmlOutboundInterceptor,
+            cacheSetupOutboundInterceptor,
+            performanceLoggerOutboundInterceptor,
+            cacheEndOutboundInterceptor,
+            performanceLoggerInboundInterceptor,
+            xmlInboundInterceptor,
+            sdtUnmarshallInterceptor
+        );
+
+        assertNotNull(result);
+    }
+
+}

--- a/consumers/src/unit-test/java/uk/gov/moj/sdt/consumers/listener/CustomListenerTest.java
+++ b/consumers/src/unit-test/java/uk/gov/moj/sdt/consumers/listener/CustomListenerTest.java
@@ -1,0 +1,42 @@
+package uk.gov.moj.sdt.consumers.listener;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.ServletContextEvent;
+
+import static org.mockito.ArgumentMatchers.any;
+
+@ExtendWith(MockitoExtension.class)
+public class CustomListenerTest {
+
+    CustomListener customListener;
+
+    @Mock
+    ServletContextEvent mockServletContextEvent;
+
+    @Mock
+    Logger mockLogger;
+
+    @Test
+    void testContextMethods() {
+        try (MockedStatic<LoggerFactory> mockLoggerFactory = Mockito.mockStatic(LoggerFactory.class)) {
+            mockLoggerFactory.when(() -> LoggerFactory.getLogger(any(Class.class)))
+                    .thenReturn(mockLogger);
+
+            customListener = new CustomListener();
+            customListener.contextInitialized(mockServletContextEvent);
+            customListener.contextDestroyed(mockServletContextEvent);
+
+            Mockito.verify(mockLogger).info("CustomListener is initialized");
+            Mockito.verify(mockLogger).info("CustomListener is destroyed");
+        }
+
+    }
+}

--- a/domain/src/unit-test/java/uk/gov/moj/sdt/domain/BulkCustomerTest.java
+++ b/domain/src/unit-test/java/uk/gov/moj/sdt/domain/BulkCustomerTest.java
@@ -41,6 +41,8 @@ import uk.gov.moj.sdt.domain.api.IBulkCustomer;
 import uk.gov.moj.sdt.domain.api.IBulkCustomerApplication;
 import uk.gov.moj.sdt.domain.api.ITargetApplication;
 import uk.gov.moj.sdt.utils.AbstractSdtUnitTestBase;
+import uk.gov.moj.sdt.utils.visitor.api.ITree;
+import uk.gov.moj.sdt.utils.visitor.api.IVisitor;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -50,6 +52,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 /**
  * Unit tests for {@link BulkCustomer}.
@@ -79,6 +83,7 @@ class BulkCustomerTest extends AbstractSdtUnitTestBase {
 
         bulkCustomer.setBulkCustomerApplications(bulkCustomerApplications);
         bulkCustomer.setId(1L);
+        bulkCustomer.setSdtCustomerId(1L);
     }
 
     /**
@@ -96,8 +101,20 @@ class BulkCustomerTest extends AbstractSdtUnitTestBase {
     void testIBulkCustomer(){
         assertNotNull(bulkCustomer,"BulkCustomer Object should be populated");
         assertEquals(1L, bulkCustomer.getId(), "Id should be populated");
+        assertEquals(1L, bulkCustomer.getSdtCustomerId(), "SdtCustomerId should be populated");
         final String hashcode = Integer.toHexString(bulkCustomer.hashCode());
         assertTrue(bulkCustomer.toString().contains(hashcode),"Object toString should be populated");
+    }
+
+    @Test
+    @DisplayName("Test AbstractDomainObject accept")
+    void testAccept() {
+        IVisitor mockVisitor = mock(IVisitor.class);
+        ITree mockTree = mock(ITree.class);
+
+        bulkCustomer.accept(mockVisitor, mockTree);
+
+        verify(mockVisitor).visit(bulkCustomer, mockTree);
     }
 
     @Test
@@ -111,14 +128,14 @@ class BulkCustomerTest extends AbstractSdtUnitTestBase {
     @Test
     @DisplayName("Test Abstract Domain Object for Persistent Collection type")
     void testGetHashIdForPersistentCollection() {
-        PersistentCollection mockPersistentCollection = Mockito.mock(PersistentCollection.class);
+        PersistentCollection mockPersistentCollection = mock(PersistentCollection.class);
         assertEquals("PersistentCollection", new BulkCustomer().getHashId(mockPersistentCollection));
     }
 
     @Test
     @DisplayName("Test Abstract Domain Object for Hibernate Proxy type")
     void testGetHashIdForHibernateProxy() {
-        HibernateProxy mockHibernateProxy = Mockito.mock(HibernateProxy.class);
+        HibernateProxy mockHibernateProxy = mock(HibernateProxy.class);
         assertEquals("HibernateProxy", new BulkCustomer().getHashId(mockHibernateProxy));
     }
 

--- a/domain/src/unit-test/java/uk/gov/moj/sdt/domain/GlobalParameterTest.java
+++ b/domain/src/unit-test/java/uk/gov/moj/sdt/domain/GlobalParameterTest.java
@@ -42,6 +42,7 @@ import org.junit.jupiter.api.Test;
 import uk.gov.moj.sdt.domain.api.IGlobalParameter;
 import uk.gov.moj.sdt.utils.AbstractSdtUnitTestBase;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisplayName("Global Parameter Test")
@@ -72,5 +73,18 @@ class GlobalParameterTest extends AbstractSdtUnitTestBase {
         String expected = "MCOL_INDV_REQ_DELAY";
         String actual = globalParameter.toString();
         assertTrue(actual.contains(expected), "Should contain something");
+    }
+
+    @Test
+    @DisplayName("Test ParameterKey enum order")
+    void testGlobalParameterKeys() {
+        assertEquals(0, IGlobalParameter.ParameterKey.DATA_RETENTION_PERIOD.ordinal());
+        assertEquals(1, IGlobalParameter.ParameterKey.TARGET_APP_TIMEOUT.ordinal());
+        assertEquals(2, IGlobalParameter.ParameterKey.MAX_FORWARDING_ATTEMPTS.ordinal());
+        assertEquals(3, IGlobalParameter.ParameterKey.MAX_CONCURRENT_INDV_REQ.ordinal());
+        assertEquals(4, IGlobalParameter.ParameterKey.INDV_REQ_DELAY.ordinal());
+        assertEquals(5, IGlobalParameter.ParameterKey.MAX_CONCURRENT_QUERY_REQ.ordinal());
+        assertEquals(6, IGlobalParameter.ParameterKey.CONTACT_DETAILS.ordinal());
+        assertEquals(7, IGlobalParameter.ParameterKey.TARGET_APP_RESP_TIMEOUT.ordinal());
     }
 }

--- a/producers/src/unit-test/java/uk/gov/moj/sdt/producers/sdtws/config/ProducersConfigTest.java
+++ b/producers/src/unit-test/java/uk/gov/moj/sdt/producers/sdtws/config/ProducersConfigTest.java
@@ -1,0 +1,97 @@
+package uk.gov.moj.sdt.producers.sdtws.config;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jmx.export.MBeanExporter;
+import org.springframework.jmx.export.assembler.MBeanInfoAssembler;
+import org.springframework.jmx.export.assembler.MethodNameBasedMBeanInfoAssembler;
+import org.springframework.jmx.support.RegistrationPolicy;
+import uk.gov.moj.sdt.utils.AbstractSdtUnitTestBase;
+import uk.gov.moj.sdt.utils.mbeans.api.ISdtManagementMBean;
+import uk.gov.moj.sdt.utils.mbeans.api.ISdtMetricsMBean;
+
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(MockitoExtension.class)
+public class ProducersConfigTest extends AbstractSdtUnitTestBase {
+
+    private ProducersConfig producersConfig;
+
+    @Mock
+    ISdtManagementMBean mockSdtManagementMBean;
+
+    @Mock
+    ISdtMetricsMBean mockSdtMetricsMBean;
+
+    @BeforeEach
+    @Override
+    public void setUp() {
+        producersConfig = new ProducersConfig();
+    }
+
+    @Test
+    void testMBeanExporter() {
+        MBeanExporter result = producersConfig.mBeanExporter(mockSdtManagementMBean);
+
+        Map<String, Object> resultBeans = (Map<String, Object>) getAccessibleField(
+            MBeanExporter.class,
+            "beans",
+            Map.class,
+            result);
+        MBeanInfoAssembler resultAssembler = (MBeanInfoAssembler) getAccessibleField(
+            MBeanExporter.class,
+            "assembler",
+            MBeanInfoAssembler.class,
+            result);
+        Set<String> resultManagedMethods = (Set<String>) getAccessibleField(
+            MethodNameBasedMBeanInfoAssembler.class,
+            "managedMethods",
+            Set.class,
+            resultAssembler);
+        RegistrationPolicy resultRegistrationPolicy = (RegistrationPolicy) getAccessibleField(
+            MBeanExporter.class,
+            "registrationPolicy",
+            RegistrationPolicy.class,
+            result);
+
+        assertEquals(1, resultBeans.size());
+        assertEquals(4, resultManagedMethods.size());
+        assertEquals(RegistrationPolicy.REPLACE_EXISTING, resultRegistrationPolicy);
+    }
+
+    @Test
+    void testMBeanExporterProducerMetrics() {
+        MBeanExporter result = producersConfig.mBeanExporterProducerMetrics(mockSdtMetricsMBean);
+
+        Map<String, Object> resultBeans = (Map<String, Object>) getAccessibleField(
+            MBeanExporter.class,
+            "beans",
+            Map.class,
+            result);
+        MBeanInfoAssembler resultAssembler = (MBeanInfoAssembler) getAccessibleField(
+            MBeanExporter.class,
+            "assembler",
+            MBeanInfoAssembler.class,
+            result);
+        Set<String> resultManagedMethods = (Set<String>) getAccessibleField(
+            MethodNameBasedMBeanInfoAssembler.class,
+            "managedMethods",
+            Set.class,
+            resultAssembler);
+        RegistrationPolicy resultRegistrationPolicy = (RegistrationPolicy) getAccessibleField(
+            MBeanExporter.class,
+            "registrationPolicy",
+            RegistrationPolicy.class,
+            result);
+
+        assertEquals(1, resultBeans.size());
+        assertEquals(20, resultManagedMethods.size());
+        assertEquals(RegistrationPolicy.REPLACE_EXISTING, resultRegistrationPolicy);
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
[SDT-113](https://tools.hmcts.net/jira/browse/SDT-113)


### Change description ###
Address unit tests identified in the following report:

```
Consumers : class coverage rate is: 77.78%, minimum is 90%
Domain : class coverage rate is: 86.96%, minimum is 90%
Producers : class coverage rate is: 66.67%, minimum is 90%
Producers-api : class coverage rate is: 0.0%, minimum is 90%
Services: OK Passed (90%+)
Transformers: OK Passed (90%+)
Utils: OK Passed (90%+)
Validators: OK Passed (90%+)
Handlers: OK Passed (90%+)
Interceptors: OK Passed (90%+)
```


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
