### PR TITLE
Stop nightly builds running at weekends

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -2,7 +2,7 @@
 
 properties([
   // H allow predefined but random minute see https://en.wikipedia.org/wiki/Cron#Non-standard_characters
-  pipelineTriggers([cron('H 05 * * *')])
+  pipelineTriggers([cron('H 05 * * 1-5')])
 ])
 
 @Library("Infrastructure")


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
Changed the schedule so that nightly builds only run during the week.  Typically no development will be taking place over a weekend so little benefit in having the nightly builds run then.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
