### PR TITLE
Add SDT key vault

### DIFF
--- a/infrastructure/key-vault.tf
+++ b/infrastructure/key-vault.tf
@@ -1,3 +1,21 @@
+data "azurerm_user_assigned_identity" "civil-mi" {
+  name                = "${var.product}-${var.env}-mi"
+  resource_group_name = "managed-identities-${var.env}-rg"
+}
+
+module "civil_sdt_key_vault" {
+  source = "git@github.com:hmcts/cnp-module-key-vault?ref=master"
+
+  name                        = "${var.product}-${var.component}-${var.env}"
+  product                     = var.product
+  env                         = var.env
+  object_id                   = var.jenkins_AAD_objectId
+  resource_group_name         = azurerm_resource_group.civil_sdt_rg.name
+  product_group_name          = "DTS Civil"
+  common_tags                 = local.tags
+  managed_identity_object_ids = [data.azurerm_user_assigned_identity.civil-mi.principal_id]
+}
+
 data "azurerm_key_vault" "civil_vault" {
   name                = "civil-shared-${var.env}"
   resource_group_name = local.civil_shared_resource_group

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -8,3 +8,8 @@ locals {
   ))
   civil_shared_resource_group = "${var.product}-shared-${var.env}"
 }
+
+resource "azurerm_resource_group" "civil_sdt_rg" {
+  name     = "${var.product}-${var.component}-${var.env}"
+  location = var.location
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
Added configuration to main.tf and key-vault.tf files to create an SDT key vault.  This will be used in place of the civil key vault which is owned by the civil-service repository.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
