### PR TITLE
Configure project to use Application Insights v3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,6 @@ bin/main/application.yaml
 
 .DS_Store
 
-applicationinsights-agent-*.jar
+lib/applicationinsights-agent-*.jar
+lib/applicationinsights.log
 *.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ ARG APP_INSIGHTS_AGENT_VERSION=3.2.10
 FROM hmctspublic.azurecr.io/base/java:17-distroless
 
 USER hmcts
+COPY lib/applicationinsights.json /opt/app
 COPY build/libs/civil-sdt.jar /opt/app/
 
 EXPOSE 4550

--- a/build.gradle
+++ b/build.gradle
@@ -511,7 +511,6 @@ subprojects { subproject ->
   }
 
   test {
-    environment("AZURE_APPLICATIONINSIGHTS_INSTRUMENTATIONKEY", "some-key")
     generateCucumberReports.enabled = false
     useJUnit()
 

--- a/charts/civil-sdt/Chart.yaml
+++ b/charts/civil-sdt/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for civil-sdt app
 name: civil-sdt
 home: https://github.com/hmcts/civil-sdt
-version: 0.0.10
+version: 0.0.11
 maintainers:
   - name: HMCTS SDT team
 dependencies:

--- a/charts/civil-sdt/values.preview.template.yaml
+++ b/charts/civil-sdt/values.preview.template.yaml
@@ -14,8 +14,6 @@ java:
   keyVaults:
     civil-sdt:
       disabled: true
-      secrets:
-        - name: AppInsightsInstrumentationKey
   secrets:
     CIVIL_SDT_SERVICEBUS_CONNECTION_STRING:
       secretRef: servicebus-secret-queue-{{ .Release.Name }}-servicebus-civil-sdt-in-out

--- a/charts/civil-sdt/values.yaml
+++ b/charts/civil-sdt/values.yaml
@@ -10,9 +10,8 @@ java:
   keyVaults:
     civil-sdt:
       secrets:
-#        Uncomment once the vault containing the app insights key has been set up
-#        - name: AppInsightsInstrumentationKey
-#          alias: azure.application-insights.instrumentation-key
+        - name: appinsights-connection-string
+          alias: appinsights-connection-string
         - name: civil-sdt-POSTGRES-USER
           alias: SDT_DB_USERNAME
         - name: civil-sdt-POSTGRES-PASS

--- a/charts/civil-sdt/values.yaml
+++ b/charts/civil-sdt/values.yaml
@@ -10,8 +10,8 @@ java:
   keyVaults:
     civil-sdt:
       secrets:
-        - name: appinsights-connection-string
-          alias: appinsights-connection-string
+        - name: civil-sdt-appinsights-connection-string
+          alias: APPINSIGHTS_CONNECTION_STRING
         - name: civil-sdt-POSTGRES-USER
           alias: SDT_DB_USERNAME
         - name: civil-sdt-POSTGRES-PASS

--- a/infrastructure/app-insights.tf
+++ b/infrastructure/app-insights.tf
@@ -1,0 +1,22 @@
+resource "azurerm_application_insights" "appinsights" {
+  name                = "${var.product}-${var.component}-appinsights-${var.env}"
+  location            = var.location
+  resource_group_name = azurerm_resource_group.civil_sdt_rg.name
+  application_type    = "web"
+
+  tags                = var.common_tags
+
+  lifecycle {
+    ignore_changes = [
+      # Ignore changes to appinsights as otherwise upgrading to the Azure provider 2.x
+      # destroys and re-creates this appinsights instance
+      application_type,
+    ]
+  }
+}
+
+resource "azurerm_key_vault_secret" "appinsights-connection-string" {
+  name         = "civil-sdt-appinsights-connection-string"
+  value        = azurerm_application_insights.appinsights.connection_string
+  key_vault_id = module.civil_sdt_key_vault.key_vault_id
+}

--- a/lib/applicationinsights.json
+++ b/lib/applicationinsights.json
@@ -1,5 +1,6 @@
 {
+  "connectionString" : "${file:/mnt/secrets/civil-sdt/appinsights-connection-string}",
   "role": {
-    "name": "civil-sdt"
+    "name": "Civil SDT"
   }
 }

--- a/lib/applicationinsights.json
+++ b/lib/applicationinsights.json
@@ -1,5 +1,5 @@
 {
-  "connectionString" : "${file:/mnt/secrets/civil-sdt/appinsights-connection-string}",
+  "connectionString": "${file:/mnt/secrets/civil-sdt/civil-sdt-appinsights-connection-string}",
   "role": {
     "name": "Civil SDT"
   }

--- a/lib/applicationinsights.json
+++ b/lib/applicationinsights.json
@@ -1,6 +1,6 @@
 {
   "connectionString": "${file:/mnt/secrets/civil-sdt/civil-sdt-appinsights-connection-string}",
   "role": {
-    "name": "Civil SDT"
+    "name": "civil-sdt"
   }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -14,7 +14,6 @@ management:
 springdoc:
   packagesToScan: uk.gov.moj.sdt.controllers
 
-#If you use a database then uncomment below lines and update db properties accordingly
 spring:
   jms:
     servicebus:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -50,9 +50,6 @@ spring:
     out-of-order: 'true'
     baseline-on-migrate: 'true'
 
-azure:
-  application-insights:
-    instrumentation-key: ${APPINSIGHTS_INSTRUMENTATIONKEY:00000000-0000-0000-0000-000000000000}
 sdt:
   tx-timeout:
     default:  1000


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
Configured civil-sdt for use with Application Insights v3.  This is based on the changes made in the example https://github.com/hmcts/draft-store/pull/989 pull request.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
