### PR TITLE
SDT-138: Improve consumers module test coverage

### DIFF
--- a/consumers/src/main/java/uk/gov/moj/sdt/cmc/consumers/api/CMCApiFallback.java
+++ b/consumers/src/main/java/uk/gov/moj/sdt/cmc/consumers/api/CMCApiFallback.java
@@ -96,7 +96,6 @@ public class CMCApiFallback implements CMCApi {
                                                                judgmentWarrantRequest);
     }
 
-
     @Override
     public ClaimResponse createSDTClaim(String idamId,
                                         String sdtRequestId,

--- a/consumers/src/unit-test/java/uk/gov/moj/sdt/cmc/consumers/api/CMCApiFallbackTest.java
+++ b/consumers/src/unit-test/java/uk/gov/moj/sdt/cmc/consumers/api/CMCApiFallbackTest.java
@@ -1,0 +1,233 @@
+package uk.gov.moj.sdt.cmc.consumers.api;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.moj.sdt.cmc.consumers.model.claimdefences.ClaimDefencesResponse;
+import uk.gov.moj.sdt.cmc.consumers.request.BreathingSpaceRequest;
+import uk.gov.moj.sdt.cmc.consumers.request.ClaimStatusUpdateRequest;
+import uk.gov.moj.sdt.cmc.consumers.request.JudgementWarrantRequest;
+import uk.gov.moj.sdt.cmc.consumers.request.WarrantRequest;
+import uk.gov.moj.sdt.cmc.consumers.request.claim.ClaimRequest;
+import uk.gov.moj.sdt.cmc.consumers.request.judgement.JudgementRequest;
+import uk.gov.moj.sdt.cmc.consumers.response.BreathingSpaceResponse;
+import uk.gov.moj.sdt.cmc.consumers.response.ClaimResponse;
+import uk.gov.moj.sdt.cmc.consumers.response.ClaimStatusUpdateResponse;
+import uk.gov.moj.sdt.cmc.consumers.response.JudgementWarrantResponse;
+import uk.gov.moj.sdt.cmc.consumers.response.WarrantResponse;
+import uk.gov.moj.sdt.cmc.consumers.response.judgement.JudgementResponse;
+
+import static com.google.common.net.HttpHeaders.AUTHORIZATION;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CMCApiFallbackTest {
+
+    private static final String IDAM_ID_HEADER = "Test IDAM id";
+    private static final String SDT_REQUEST_ID = "Test SDT Request id";
+    private static final String SERVICE_AUTHORISATION = "Test service authorisation";
+
+    private CMCApiFallback cmcApiFallback;
+
+    @Mock
+    private IBreathingSpaceService mockBreathingSpaceService;
+    @Mock
+    private BreathingSpaceRequest mockBreathingSpaceRequest;
+    @Mock
+    private BreathingSpaceResponse mockBreathingSpaceResponse;
+
+    @Mock
+    private IJudgementService mockJudgementService;
+    @Mock
+    private JudgementRequest mockJudgementRequest;
+    @Mock
+    private JudgementResponse mockJudgementResponse;
+
+    @Mock
+    private IClaimDefencesService mockClaimDefencesService;
+    @Mock
+    private ClaimDefencesResponse mockClaimDefencesResponse;
+
+    @Mock
+    private IClaimStatusUpdateService mockClaimStatusUpdateService;
+    @Mock
+    private ClaimStatusUpdateRequest mockClaimStatusUpdateRequest;
+    @Mock
+    private ClaimStatusUpdateResponse mockClaimStatusUpdateResponse;
+
+    @Mock
+    private IClaimRequestService mockClaimRequestService;
+    @Mock
+    private ClaimRequest mockClaimRequest;
+    @Mock
+    private ClaimResponse mockClaimResponse;
+
+    @Mock
+    private IWarrantService mockWarrantService;
+    @Mock
+    private WarrantRequest mockWarrantRequest;
+    @Mock
+    private WarrantResponse mockWarrantResponse;
+
+    @Mock
+    private IJudgementWarrantService mockJudgementWarrantService;
+    @Mock
+    private JudgementWarrantRequest mockJudgementWarrantRequest;
+    @Mock
+    private JudgementWarrantResponse mockJudgementWarrantResponse;
+
+    @BeforeEach
+    void setUp() {
+        cmcApiFallback = new CMCApiFallback(mockBreathingSpaceService,
+                                            mockClaimDefencesService,
+                                            mockJudgementService,
+                                            mockClaimStatusUpdateService,
+                                            mockClaimRequestService,
+                                            mockWarrantService,
+                                            mockJudgementWarrantService);
+    }
+
+    @Test
+    void testBreathingSpace() {
+        when(mockBreathingSpaceService.breathingSpace(IDAM_ID_HEADER, SDT_REQUEST_ID, mockBreathingSpaceRequest))
+            .thenReturn(mockBreathingSpaceResponse);
+
+        BreathingSpaceResponse breathingSpaceResponse =
+            cmcApiFallback.breathingSpace(IDAM_ID_HEADER, SDT_REQUEST_ID, mockBreathingSpaceRequest);
+
+        assertNotNull(breathingSpaceResponse, "BreathingSpaceResponse should not be null");
+        assertSame(mockBreathingSpaceResponse, breathingSpaceResponse, "Unexpected BreathingSpaceResponse returned");
+
+        verify(mockBreathingSpaceService).breathingSpace(IDAM_ID_HEADER, SDT_REQUEST_ID, mockBreathingSpaceRequest);
+    }
+
+    @Test
+    void testJudgementResponse() {
+        when(mockJudgementService.requestJudgment(IDAM_ID_HEADER, SDT_REQUEST_ID, mockJudgementRequest))
+            .thenReturn(mockJudgementResponse);
+
+        JudgementResponse judgementResponse =
+            cmcApiFallback.requestJudgment(IDAM_ID_HEADER, SDT_REQUEST_ID, mockJudgementRequest);
+
+        assertNotNull(judgementResponse, "JudgementResponse should not be null");
+        assertSame(mockJudgementResponse, judgementResponse, "Unexpected JudgementResponse returned");
+
+        verify(mockJudgementService).requestJudgment(IDAM_ID_HEADER, SDT_REQUEST_ID, mockJudgementRequest);
+    }
+
+    @Test
+    void testClaimStatusUpdate() {
+        when(mockClaimStatusUpdateService.claimStatusUpdate(IDAM_ID_HEADER,
+                                                            SDT_REQUEST_ID,
+                                                            mockClaimStatusUpdateRequest))
+            .thenReturn(mockClaimStatusUpdateResponse);
+
+        ClaimStatusUpdateResponse claimStatusUpdateResponse =
+            cmcApiFallback.claimStatusUpdate(IDAM_ID_HEADER, SDT_REQUEST_ID, mockClaimStatusUpdateRequest);
+
+        assertNotNull(claimStatusUpdateResponse, "ClaimStatusUpdateResponse should not be null");
+        assertSame(mockClaimStatusUpdateResponse,
+                   claimStatusUpdateResponse,
+                   "Unexpected ClaimStatusUpdateResponse returned");
+
+        verify(mockClaimStatusUpdateService).claimStatusUpdate(IDAM_ID_HEADER,
+                                                               SDT_REQUEST_ID,
+                                                               mockClaimStatusUpdateRequest);
+    }
+
+    @Test
+    void testClaimDefencesResponse() {
+        String fromDate = "2023-01-01T00:00:00";
+        String toDate = "2023-01-10T23:59:59";
+        when(mockClaimDefencesService.claimDefences(AUTHORIZATION,
+                                                    SERVICE_AUTHORISATION,
+                                                    IDAM_ID_HEADER,
+                                                    fromDate,
+                                                    toDate))
+            .thenReturn(mockClaimDefencesResponse);
+
+        ClaimDefencesResponse claimDefencesResponse =
+            cmcApiFallback.claimDefences(AUTHORIZATION, SERVICE_AUTHORISATION, IDAM_ID_HEADER, fromDate, toDate);
+
+        assertNotNull(claimDefencesResponse, "ClaimDefencesResponse should not be null");
+        assertSame(mockClaimDefencesResponse, claimDefencesResponse, "Unexpected ClaimDefencesResponse returned");
+
+        verify(mockClaimDefencesService).claimDefences(AUTHORIZATION,
+                                                       SERVICE_AUTHORISATION,
+                                                       IDAM_ID_HEADER,
+                                                       fromDate,
+                                                       toDate);
+    }
+
+    @Test
+    void testWarrantResponse() {
+        when(mockWarrantService.warrantRequest(AUTHORIZATION,
+                                               SERVICE_AUTHORISATION,
+                                               IDAM_ID_HEADER,
+                                               SDT_REQUEST_ID,
+                                               mockWarrantRequest))
+            .thenReturn(mockWarrantResponse);
+
+        WarrantResponse warrantResponse =
+            cmcApiFallback.warrantRequest(AUTHORIZATION,
+                                          SERVICE_AUTHORISATION,
+                                          IDAM_ID_HEADER,
+                                          SDT_REQUEST_ID,
+                                          mockWarrantRequest);
+
+        assertNotNull(warrantResponse, "WarrantResponse should not be nuill");
+        assertSame(mockWarrantResponse, warrantResponse, "Unexpected WarrantResponse returned");
+
+        verify(mockWarrantService).warrantRequest(AUTHORIZATION,
+                                                  SERVICE_AUTHORISATION,
+                                                  IDAM_ID_HEADER,
+                                                  SDT_REQUEST_ID,
+                                                  mockWarrantRequest);
+    }
+
+    @Test
+    void testJudgementWarrantResponse() {
+        when(mockJudgementWarrantService.judgementWarrantRequest(AUTHORIZATION,
+                                                                 SERVICE_AUTHORISATION,
+                                                                 IDAM_ID_HEADER,
+                                                                 SDT_REQUEST_ID,
+                                                                 mockJudgementWarrantRequest))
+            .thenReturn(mockJudgementWarrantResponse);
+
+        JudgementWarrantResponse judgementWarrantResponse =
+            cmcApiFallback.judgementWarrantRequest(AUTHORIZATION,
+                                                   SERVICE_AUTHORISATION,
+                                                   IDAM_ID_HEADER,
+                                                   SDT_REQUEST_ID,
+                                                   mockJudgementWarrantRequest);
+
+        assertNotNull(judgementWarrantResponse, "JudgementWarrantResponse should not be null");
+        assertSame(mockJudgementWarrantResponse,
+                   judgementWarrantResponse,
+                   "Unexpected JudgementWarrantResponse returned");
+
+        verify(mockJudgementWarrantService).judgementWarrantRequest(AUTHORIZATION,
+                                                                    SERVICE_AUTHORISATION,
+                                                                    IDAM_ID_HEADER,
+                                                                    SDT_REQUEST_ID,
+                                                                    mockJudgementWarrantRequest);
+    }
+
+    @Test
+    void testCreateSdtClaim() {
+        when(mockClaimRequestService.claimRequest(IDAM_ID_HEADER, SDT_REQUEST_ID, mockClaimRequest))
+            .thenReturn(mockClaimResponse);
+
+        ClaimResponse claimResponse = cmcApiFallback.createSDTClaim(IDAM_ID_HEADER, SDT_REQUEST_ID, mockClaimRequest);
+
+        assertNotNull(claimResponse, "ClaimResponse should not be null");
+        assertSame(mockClaimResponse, claimResponse, "Unexpected ClaimResponse returned");
+
+        verify(mockClaimRequestService).claimRequest(IDAM_ID_HEADER, SDT_REQUEST_ID, mockClaimRequest);
+    }
+}

--- a/consumers/src/unit-test/java/uk/gov/moj/sdt/cmc/consumers/client/impl/BreathingSpaceServiceTest.java
+++ b/consumers/src/unit-test/java/uk/gov/moj/sdt/cmc/consumers/client/impl/BreathingSpaceServiceTest.java
@@ -1,40 +1,47 @@
 package uk.gov.moj.sdt.cmc.consumers.client.impl;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.moj.sdt.cmc.consumers.api.CMCApi;
 import uk.gov.moj.sdt.cmc.consumers.request.BreathingSpaceRequest;
-import uk.gov.moj.sdt.utils.AbstractSdtUnitTestBase;
+import uk.gov.moj.sdt.cmc.consumers.response.BreathingSpaceResponse;
 
-import static org.mockito.Mockito.mock;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-class BreathingSpaceServiceTest extends AbstractSdtUnitTestBase {
-
-    String IDAM_ID_HEADER = "IDAMID";
-
-    String SDT_REQUEST_ID = "SDTREQUESTID";
-
-    @Mock
-    private CMCApi cmcApi;
+class BreathingSpaceServiceTest extends CMCConsumersClientTestBase {
 
     private BreathingSpaceService breathingSpaceService;
 
-    @BeforeEach
+    @Mock
+    private BreathingSpaceRequest mockBreathingSpaceRequest;
+
+    @Mock
+    private BreathingSpaceResponse mockBreathingSpaceResponse;
+
     @Override
-    public void setUp() {
-        breathingSpaceService = new BreathingSpaceService(cmcApi);
+    protected void setUpLocalTests() {
+        breathingSpaceService = new BreathingSpaceService(mockCmcApi);
     }
 
     @Test
     void getClient() {
-        BreathingSpaceRequest breathingSpaceRequest = mock(BreathingSpaceRequest.class);
-        breathingSpaceService.breathingSpace(IDAM_ID_HEADER, SDT_REQUEST_ID, breathingSpaceRequest);
-        verify(cmcApi).breathingSpace(IDAM_ID_HEADER, SDT_REQUEST_ID, breathingSpaceRequest);
+        when(mockCmcApi.breathingSpace(IDAM_ID_HEADER,
+                                       SDT_REQUEST_ID,
+                                       mockBreathingSpaceRequest))
+            .thenReturn(mockBreathingSpaceResponse);
+
+        BreathingSpaceResponse breathingSpaceResponse =
+            breathingSpaceService.breathingSpace(IDAM_ID_HEADER, SDT_REQUEST_ID, mockBreathingSpaceRequest);
+
+        assertNotNull(breathingSpaceResponse, "BreathingSpaceResponse should not be null");
+        assertEquals(mockBreathingSpaceResponse, breathingSpaceResponse, "Unexpected BreathingSpaceResponse returned");
+
+        verify(mockCmcApi).breathingSpace(IDAM_ID_HEADER, SDT_REQUEST_ID, mockBreathingSpaceRequest);
     }
 
 }

--- a/consumers/src/unit-test/java/uk/gov/moj/sdt/cmc/consumers/client/impl/CMCConsumersClientTestBase.java
+++ b/consumers/src/unit-test/java/uk/gov/moj/sdt/cmc/consumers/client/impl/CMCConsumersClientTestBase.java
@@ -1,0 +1,18 @@
+package uk.gov.moj.sdt.cmc.consumers.client.impl;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.moj.sdt.cmc.consumers.api.CMCApi;
+import uk.gov.moj.sdt.utils.AbstractSdtUnitTestBase;
+
+@ExtendWith(MockitoExtension.class)
+public class CMCConsumersClientTestBase extends AbstractSdtUnitTestBase {
+
+    public static final String IDAM_ID_HEADER = "Test IDAM id";
+    public static final String SDT_REQUEST_ID = "Test SDT Request id";
+    public static final String SERVICE_AUTHORISATION = "Test service authorisation";
+
+    @Mock
+    protected CMCApi mockCmcApi;
+}

--- a/consumers/src/unit-test/java/uk/gov/moj/sdt/cmc/consumers/client/impl/ClaimDefenceServiceTest.java
+++ b/consumers/src/unit-test/java/uk/gov/moj/sdt/cmc/consumers/client/impl/ClaimDefenceServiceTest.java
@@ -1,56 +1,57 @@
 package uk.gov.moj.sdt.cmc.consumers.client.impl;
 
-import java.util.List;
-
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.moj.sdt.cmc.consumers.api.CMCApi;
 import uk.gov.moj.sdt.cmc.consumers.model.claimdefences.ClaimDefencesResponse;
 import uk.gov.moj.sdt.cmc.consumers.model.claimdefences.ClaimDefencesResult;
 import uk.gov.moj.sdt.consumers.util.ClaimDefencesResultsUtil;
-import uk.gov.moj.sdt.response.SubmitQueryResponse;
-import uk.gov.moj.sdt.utils.AbstractSdtUnitTestBase;
 
+import java.util.List;
+
+import static com.google.common.net.HttpHeaders.AUTHORIZATION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-class ClaimDefenceServiceTest extends AbstractSdtUnitTestBase {
-
-    @Mock
-    private CMCApi cmcApi;
+class ClaimDefenceServiceTest extends CMCConsumersClientTestBase {
 
     private ClaimDefencesService claimDefencesService;
 
-    @BeforeEach
     @Override
-    public void setUp() {
-        claimDefencesService = new ClaimDefencesService(cmcApi);
+    protected void setUpLocalTests() {
+        claimDefencesService = new ClaimDefencesService(mockCmcApi);
     }
 
     @Test
     void shouldReturnClaimDefencesResponse() {
-        final ClaimDefencesResponse claimDefencesResponse = createClaimDefencesResponse();
-        when(cmcApi.claimDefences(anyString(), anyString(), anyString(), anyString(), anyString())).thenReturn(claimDefencesResponse);
         String fromDateTime = "2020-01-22T11:12:13";
         String toDateTime = "2020-12-01T13:14:15";
-        ClaimDefencesResponse returnValue = claimDefencesService.claimDefences("", "", "",
-                fromDateTime, toDateTime);
-        assertNotNull(returnValue);
-        assertEquals(claimDefencesResponse.getResults(), returnValue.getResults());
-        assertEquals(claimDefencesResponse.getResultCount(), returnValue.getResultCount());
-    }
+        final ClaimDefencesResponse claimDefencesResponse = createClaimDefencesResponse();
+        when(mockCmcApi.claimDefences(AUTHORIZATION, SERVICE_AUTHORISATION, IDAM_ID_HEADER, fromDateTime, toDateTime))
+            .thenReturn(claimDefencesResponse);
 
-    private SubmitQueryResponse createSubmitQueryResponse(ClaimDefencesResponse claimDefencesResponse) {
-        SubmitQueryResponse submitQueryResponse = new SubmitQueryResponse();
-        submitQueryResponse.setClaimDefencesResultsCount(claimDefencesResponse.getResultCount());
-        submitQueryResponse.setClaimDefencesResults(claimDefencesResponse.getResults());
-        return submitQueryResponse;
+        ClaimDefencesResponse returnValue = claimDefencesService.claimDefences(AUTHORIZATION,
+                                                                               SERVICE_AUTHORISATION,
+                                                                               IDAM_ID_HEADER,
+                                                                               fromDateTime,
+                                                                               toDateTime);
+
+        assertNotNull(returnValue, "ClaimDefencesResponse should not be null");
+        assertEquals(claimDefencesResponse.getResults(),
+                     returnValue.getResults(),
+                     "Unexpected ClaimDefencesResponse returned");
+        assertEquals(claimDefencesResponse.getResultCount(),
+                     returnValue.getResultCount(),
+                     "Unexpected number of results in ClaimDefencesResponse");
+
+        verify(mockCmcApi).claimDefences(AUTHORIZATION,
+                                         SERVICE_AUTHORISATION,
+                                         IDAM_ID_HEADER,
+                                         fromDateTime,
+                                         toDateTime);
     }
 
     private ClaimDefencesResponse createClaimDefencesResponse() {

--- a/consumers/src/unit-test/java/uk/gov/moj/sdt/cmc/consumers/client/impl/ClaimRequestServiceTest.java
+++ b/consumers/src/unit-test/java/uk/gov/moj/sdt/cmc/consumers/client/impl/ClaimRequestServiceTest.java
@@ -1,0 +1,43 @@
+package uk.gov.moj.sdt.cmc.consumers.client.impl;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.moj.sdt.cmc.consumers.request.claim.ClaimRequest;
+import uk.gov.moj.sdt.cmc.consumers.response.ClaimResponse;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ClaimRequestServiceTest extends CMCConsumersClientTestBase {
+
+    private ClaimRequestService claimRequestService;
+
+    @Mock
+    private ClaimRequest mockClaimRequest;
+
+    @Mock
+    private ClaimResponse mockClaimResponse;
+
+    @Override
+    protected void setUpLocalTests() {
+        claimRequestService = new ClaimRequestService(mockCmcApi);
+    }
+
+    @Test
+    void testClaimRequest() {
+        when(mockCmcApi.createSDTClaim(IDAM_ID_HEADER, SDT_REQUEST_ID, mockClaimRequest)).thenReturn(mockClaimResponse);
+
+        ClaimResponse claimResponse = claimRequestService.claimRequest(IDAM_ID_HEADER, SDT_REQUEST_ID, mockClaimRequest);
+
+        assertNotNull(claimResponse, "ClaimResponse should not be null");
+        assertSame(mockClaimResponse, claimResponse, "Unexpected ClaimResponse object returned");
+
+        verify(mockCmcApi).createSDTClaim(IDAM_ID_HEADER, SDT_REQUEST_ID, mockClaimRequest);
+    }
+
+}

--- a/consumers/src/unit-test/java/uk/gov/moj/sdt/cmc/consumers/client/impl/ClaimStatusUpdateServiceTest.java
+++ b/consumers/src/unit-test/java/uk/gov/moj/sdt/cmc/consumers/client/impl/ClaimStatusUpdateServiceTest.java
@@ -1,40 +1,47 @@
 package uk.gov.moj.sdt.cmc.consumers.client.impl;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.moj.sdt.cmc.consumers.api.CMCApi;
 import uk.gov.moj.sdt.cmc.consumers.request.ClaimStatusUpdateRequest;
-import uk.gov.moj.sdt.utils.AbstractSdtUnitTestBase;
+import uk.gov.moj.sdt.cmc.consumers.response.ClaimStatusUpdateResponse;
 
-import static org.mockito.Mockito.mock;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-class ClaimStatusUpdateServiceTest extends AbstractSdtUnitTestBase {
-
-    String IDAM_ID_HEADER = "IDAMID";
-
-    String SDT_REQUEST_ID = "SDTREQUESTID";
-
-    @Mock
-    private CMCApi cmcApi;
+class ClaimStatusUpdateServiceTest extends CMCConsumersClientTestBase {
 
     private ClaimStatusUpdateService claimStatusUpdateService;
 
-    @BeforeEach
+    @Mock
+    ClaimStatusUpdateRequest mockClaimStatusUpdateRequest;
+
+    @Mock
+    ClaimStatusUpdateResponse mockClaimStatusUpdateResponse;
+
     @Override
-    public void setUp() {
-        claimStatusUpdateService = new ClaimStatusUpdateService(cmcApi);
+    protected void setUpLocalTests() {
+        claimStatusUpdateService = new ClaimStatusUpdateService(mockCmcApi);
     }
 
     @Test
     void getClient() {
-        ClaimStatusUpdateRequest claimStatusUpdateRequest = mock(ClaimStatusUpdateRequest.class);
-        claimStatusUpdateService.claimStatusUpdate(IDAM_ID_HEADER, SDT_REQUEST_ID, claimStatusUpdateRequest);
-        verify(cmcApi).claimStatusUpdate(IDAM_ID_HEADER, SDT_REQUEST_ID, claimStatusUpdateRequest);
+        when(mockCmcApi.claimStatusUpdate(IDAM_ID_HEADER, SDT_REQUEST_ID, mockClaimStatusUpdateRequest))
+            .thenReturn(mockClaimStatusUpdateResponse);
+
+        ClaimStatusUpdateResponse claimStatusUpdateResponse =
+            claimStatusUpdateService.claimStatusUpdate(IDAM_ID_HEADER, SDT_REQUEST_ID, mockClaimStatusUpdateRequest);
+
+        assertNotNull(claimStatusUpdateResponse, "ClaimStatusUpdateResponse should not be null");
+        assertEquals(mockClaimStatusUpdateResponse,
+                     claimStatusUpdateResponse,
+                     "Unexpected ClaimStatusUpdateResponse returned");
+
+        verify(mockCmcApi).claimStatusUpdate(IDAM_ID_HEADER, SDT_REQUEST_ID, mockClaimStatusUpdateRequest);
     }
 
 }

--- a/consumers/src/unit-test/java/uk/gov/moj/sdt/cmc/consumers/client/impl/JudgementRequestServiceTest.java
+++ b/consumers/src/unit-test/java/uk/gov/moj/sdt/cmc/consumers/client/impl/JudgementRequestServiceTest.java
@@ -1,0 +1,45 @@
+package uk.gov.moj.sdt.cmc.consumers.client.impl;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.moj.sdt.cmc.consumers.request.judgement.JudgementRequest;
+import uk.gov.moj.sdt.cmc.consumers.response.judgement.JudgementResponse;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class JudgementRequestServiceTest extends CMCConsumersClientTestBase {
+
+    private JudgementRequestService judgementRequestService;
+
+    @Mock
+    private JudgementRequest mockJudgementRequest;
+
+    @Mock
+    private JudgementResponse mockJudgementResponse;
+
+    @Override
+    protected void setUpLocalTests() {
+        judgementRequestService = new JudgementRequestService(mockCmcApi);
+    }
+
+    @Test
+    void testRequestJudgement() {
+        when(mockCmcApi.requestJudgment(IDAM_ID_HEADER, SDT_REQUEST_ID, mockJudgementRequest))
+            .thenReturn(mockJudgementResponse);
+
+        JudgementResponse judgementResponse =
+            judgementRequestService.requestJudgment(IDAM_ID_HEADER, SDT_REQUEST_ID, mockJudgementRequest);
+
+        assertNotNull(judgementResponse, "JudgementResponse should not be null");
+        assertSame(mockJudgementResponse, judgementResponse, "Unexpected JudgementResponse returned");
+
+        verify(mockCmcApi).requestJudgment(IDAM_ID_HEADER, SDT_REQUEST_ID, mockJudgementRequest);
+    }
+
+}

--- a/consumers/src/unit-test/java/uk/gov/moj/sdt/cmc/consumers/client/impl/JudgementWarrantServiceTest.java
+++ b/consumers/src/unit-test/java/uk/gov/moj/sdt/cmc/consumers/client/impl/JudgementWarrantServiceTest.java
@@ -1,0 +1,59 @@
+package uk.gov.moj.sdt.cmc.consumers.client.impl;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.moj.sdt.cmc.consumers.request.JudgementWarrantRequest;
+import uk.gov.moj.sdt.cmc.consumers.response.JudgementWarrantResponse;
+
+import static com.google.common.net.HttpHeaders.AUTHORIZATION;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class JudgementWarrantServiceTest extends CMCConsumersClientTestBase {
+
+    private JudgementWarrantService judgementWarrantService;
+
+    @Mock
+    private JudgementWarrantRequest mockJudgementWarrantRequest;
+
+    @Mock
+    private JudgementWarrantResponse mockJudgementWarrantResponse;
+
+    @Override
+    protected void setUpLocalTests() {
+        judgementWarrantService = new JudgementWarrantService(mockCmcApi);
+    }
+
+    @Test
+    void testJudgementWarrantRequest() {
+        when(mockCmcApi.judgementWarrantRequest(AUTHORIZATION,
+                                                SERVICE_AUTHORISATION,
+                                                IDAM_ID_HEADER,
+                                                SDT_REQUEST_ID,
+                                                mockJudgementWarrantRequest))
+            .thenReturn(mockJudgementWarrantResponse);
+
+        JudgementWarrantResponse judgementWarrantResponse =
+            judgementWarrantService.judgementWarrantRequest(AUTHORIZATION,
+                                                            SERVICE_AUTHORISATION,
+                                                            IDAM_ID_HEADER,
+                                                            SDT_REQUEST_ID,
+                                                            mockJudgementWarrantRequest);
+
+        assertNotNull(judgementWarrantResponse, "JudgementWarrantResponse should not be null");
+        assertSame(mockJudgementWarrantResponse,
+                   judgementWarrantResponse,
+                   "Unexpected JudgementWarrantResponse returned");
+
+        verify(mockCmcApi).judgementWarrantRequest(AUTHORIZATION,
+                                                   SERVICE_AUTHORISATION,
+                                                   IDAM_ID_HEADER,
+                                                   SDT_REQUEST_ID,
+                                                   mockJudgementWarrantRequest);
+    }
+}

--- a/consumers/src/unit-test/java/uk/gov/moj/sdt/cmc/consumers/client/impl/WarrantServiceTest.java
+++ b/consumers/src/unit-test/java/uk/gov/moj/sdt/cmc/consumers/client/impl/WarrantServiceTest.java
@@ -1,44 +1,57 @@
 package uk.gov.moj.sdt.cmc.consumers.client.impl;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.moj.sdt.cmc.consumers.api.CMCApi;
 import uk.gov.moj.sdt.cmc.consumers.request.WarrantRequest;
-import uk.gov.moj.sdt.utils.AbstractSdtUnitTestBase;
+import uk.gov.moj.sdt.cmc.consumers.response.WarrantResponse;
 
-import static org.mockito.Mockito.mock;
+import static com.google.common.net.HttpHeaders.AUTHORIZATION;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-class WarrantServiceTest extends AbstractSdtUnitTestBase {
-
-    String AUTHORISATION = "";
-
-    String SERVICE_AUTHORISATION = "";
-
-    String IDAM_ID_HEADER = "IDAMID";
-
-    String SDT_REQUEST_ID = "SDTREQUESTID";
-
-    @Mock
-    private CMCApi cmcApi;
+class WarrantServiceTest extends CMCConsumersClientTestBase {
 
     private WarrantService warrantService;
 
-    @BeforeEach
+    @Mock
+    private WarrantRequest mockWarrantRequest;
+
+    @Mock
+    private WarrantResponse mockWarrantResponse;
+
     @Override
-    public void setUp() {
-        warrantService = new WarrantService(cmcApi);
+    protected void setUpLocalTests() {
+        warrantService = new WarrantService(mockCmcApi);
     }
 
     @Test
-    void warrentRequest() {
-        WarrantRequest request = mock(WarrantRequest.class);
-        warrantService.warrantRequest(AUTHORISATION, SERVICE_AUTHORISATION, IDAM_ID_HEADER, SDT_REQUEST_ID, request);
-        verify(cmcApi).warrantRequest(AUTHORISATION, SERVICE_AUTHORISATION, IDAM_ID_HEADER, SDT_REQUEST_ID, request);
+    void warrantRequest() {
+        when(mockCmcApi.warrantRequest(AUTHORIZATION,
+                                       SERVICE_AUTHORISATION,
+                                       IDAM_ID_HEADER,
+                                       SDT_REQUEST_ID,
+                                       mockWarrantRequest))
+            .thenReturn(mockWarrantResponse);
+
+        WarrantResponse warrantResponse = warrantService.warrantRequest(AUTHORIZATION,
+                                                                        SERVICE_AUTHORISATION,
+                                                                        IDAM_ID_HEADER,
+                                                                        SDT_REQUEST_ID,
+                                                                        mockWarrantRequest);
+
+        assertNotNull(warrantResponse, "WarrantResponse should not be null");
+        assertEquals(mockWarrantResponse, warrantResponse, "Unexpected WarrantResponse returned");
+
+        verify(mockCmcApi).warrantRequest(AUTHORIZATION,
+                                          SERVICE_AUTHORISATION,
+                                          IDAM_ID_HEADER,
+                                          SDT_REQUEST_ID,
+                                          mockWarrantRequest);
     }
 
 }

--- a/consumers/src/unit-test/java/uk/gov/moj/sdt/cmc/consumers/client/mock/MockClaimRequestServiceTest.java
+++ b/consumers/src/unit-test/java/uk/gov/moj/sdt/cmc/consumers/client/mock/MockClaimRequestServiceTest.java
@@ -1,0 +1,29 @@
+package uk.gov.moj.sdt.cmc.consumers.client.mock;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.moj.sdt.cmc.consumers.request.claim.ClaimRequest;
+import uk.gov.moj.sdt.cmc.consumers.response.ClaimResponse;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class MockClaimRequestServiceTest {
+
+    private MockClaimRequestService mockClaimRequestService;
+
+    @BeforeEach
+    void setUp() {
+        mockClaimRequestService = new MockClaimRequestService();
+    }
+
+    @Test
+    void shouldReturnMockClaimRequestResponse() {
+        ClaimRequest claimRequest = new ClaimRequest();
+
+        ClaimResponse claimResponse = mockClaimRequestService.claimRequest("testIdamId",
+                                                                           "MCOL-20230713091446-000000001-0000001",
+                                                                           claimRequest);
+
+        assertNotNull(claimResponse, "Claim response should not be null");
+    }
+}

--- a/consumers/src/unit-test/java/uk/gov/moj/sdt/cmc/consumers/model/DefendantResponseTypeTest.java
+++ b/consumers/src/unit-test/java/uk/gov/moj/sdt/cmc/consumers/model/DefendantResponseTypeTest.java
@@ -1,0 +1,87 @@
+package uk.gov.moj.sdt.cmc.consumers.model;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.moj.sdt.utils.AbstractSdtUnitTestBase;
+import uk.gov.moj.sdt.utils.Utilities;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Calendar;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DefendantResponseTypeTest extends AbstractSdtUnitTestBase {
+
+    private DefendantResponseType defendantResponseType;
+
+    @Override
+    protected void setUpLocalTests() {
+        defendantResponseType = new DefendantResponseType();
+    }
+
+    @Test
+    void testFiledDate() {
+        LocalDateTime testDate = LocalDateTime.of(2023, 1, 1, 0, 0);
+        Calendar testFiledDate = Utilities.convertLocalDateTimeToCalendar(testDate);
+
+        defendantResponseType.setFiledDate(testFiledDate);
+        Calendar actualFiledDate = defendantResponseType.getFiledDate();
+
+        assertDate(testDate, actualFiledDate);
+    }
+
+    @Test
+    void testEventCreatedDateOnMcol() {
+        LocalDateTime testDate = LocalDateTime.of(2023, 2, 2, 0, 0);
+        Calendar testEventCreatedDateOnMcol = Utilities.convertLocalDateTimeToCalendar(testDate);
+
+        defendantResponseType.setEventCreatedDateOnMcol(testEventCreatedDateOnMcol);
+        Calendar actualEventCreatedDateOnMcol = defendantResponseType.getEventCreatedDateOnMcol();
+
+        assertDate(testDate, actualEventCreatedDateOnMcol);
+    }
+
+    @Test
+    void testRaisedOnMcol() {
+        defendantResponseType.setRaisedOnMcol(true);
+
+        assertTrue(defendantResponseType.isRaisedOnMcol(), "Unexpected raisedOnMcol value");
+    }
+
+    @Test
+    void testResponseType() {
+        ResponseType responseType = ResponseType.AS;
+
+        defendantResponseType.setResponseType(responseType);
+
+        assertEquals(responseType.value(),
+                     defendantResponseType.getResponseType().value(),
+                     "Unexpected ResponseType value");
+    }
+
+    @Test
+    void testDefence() {
+        String defence = "This is the defence";
+
+        defendantResponseType.setDefence(defence);
+
+        assertEquals(defence, defendantResponseType.getDefence(), "Unexpected defence value");
+    }
+
+    @Test
+    void testDefendantId() {
+        String defendantId = "1";
+
+        defendantResponseType.setDefendantId(defendantId);
+
+        assertEquals(defendantId, defendantResponseType.getDefendantId(), "Unexpected defendantId value");
+    }
+
+    private void assertDate(LocalDateTime expectedDate, Calendar actualDate) {
+        // Convert Calendar to a LocalDateTime to allow comparison
+        LocalDateTime actualLocalDateTime = LocalDateTime.ofInstant(actualDate.toInstant(), ZoneId.systemDefault());
+
+        assertTrue(expectedDate.isEqual(actualLocalDateTime), "Date does not match the expected date");
+    }
+}

--- a/consumers/src/unit-test/java/uk/gov/moj/sdt/cmc/consumers/request/WarrantRequestTest.java
+++ b/consumers/src/unit-test/java/uk/gov/moj/sdt/cmc/consumers/request/WarrantRequestTest.java
@@ -1,0 +1,41 @@
+package uk.gov.moj.sdt.cmc.consumers.request;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.moj.sdt.cmc.consumers.request.common.SotSignature;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class WarrantRequestTest {
+
+    private static final String STATEMENT_OF_TRUTH_NAME = "Test SoT Name";
+
+    private WarrantRequest warrantRequest;
+
+    @BeforeEach
+    void setup() {
+        warrantRequest = new WarrantRequest();
+    }
+
+    @Test
+    void testGetSotName() {
+        SotSignature sotSignature = new SotSignature();
+        sotSignature.setName(STATEMENT_OF_TRUTH_NAME);
+
+        warrantRequest.setSotSignature(sotSignature);
+
+        assertEquals(STATEMENT_OF_TRUTH_NAME,
+                     warrantRequest.getSotName(),
+                     "WarrantRequest has unexpected statement of truth name");
+    }
+
+    @Test
+    void testGetSotNameNull() {
+        warrantRequest.setSotSignature(null);
+
+        String sotName = warrantRequest.getSotName();
+        assertNotNull(sotName, "WarrantRequest statement of truth name should not be null");
+        assertEquals("", sotName, "WarrantRequest should have an empty string for statement of truth name");
+    }
+}

--- a/consumers/src/unit-test/java/uk/gov/moj/sdt/cmc/consumers/request/common/SotSignatureTest.java
+++ b/consumers/src/unit-test/java/uk/gov/moj/sdt/cmc/consumers/request/common/SotSignatureTest.java
@@ -1,0 +1,33 @@
+package uk.gov.moj.sdt.cmc.consumers.request.common;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.moj.sdt.utils.AbstractSdtUnitTestBase;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SotSignatureTest extends AbstractSdtUnitTestBase {
+
+    private static final String STATEMENT_OF_TRUTH_NAME = "Test SoT Name";
+
+    private SotSignature sotSignature;
+
+    @Override
+    protected void setUpLocalTests() {
+        sotSignature = new SotSignature();
+    }
+
+    @Test
+    void testGetName() {
+        setAccessibleField(SotSignature.class, "name", String.class, sotSignature, STATEMENT_OF_TRUTH_NAME);
+
+        assertEquals(STATEMENT_OF_TRUTH_NAME, sotSignature.getName(), "SotSignature does not have expected name");
+    }
+
+    @Test
+    void testGetFlag() {
+        setAccessibleField(SotSignature.class, "flag", Boolean.class, sotSignature, Boolean.TRUE);
+
+        assertTrue(sotSignature.getFlag(), "SotSignature flag should be true");
+    }
+}

--- a/consumers/src/unit-test/java/uk/gov/moj/sdt/cmc/consumers/request/judgement/InstalmentPaymentTypeTest.java
+++ b/consumers/src/unit-test/java/uk/gov/moj/sdt/cmc/consumers/request/judgement/InstalmentPaymentTypeTest.java
@@ -1,0 +1,42 @@
+package uk.gov.moj.sdt.cmc.consumers.request.judgement;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class InstalmentPaymentTypeTest {
+
+    private InstalmentPaymentType instalmentPaymentType;
+
+
+    @BeforeEach
+    void setUp() {
+        instalmentPaymentType = new InstalmentPaymentType();
+    }
+
+    @Test
+    void testAmount() {
+        Long amount = 2L;
+        instalmentPaymentType.setAmount(amount);
+
+        Long actualAmount = instalmentPaymentType.getAmount();
+
+        assertNotNull(actualAmount, "InstalmentPaymentType amount should not be null");
+        assertEquals(amount, instalmentPaymentType.getAmount(), "InstalmentPaymentType has unexpected amount");
+    }
+
+    @Test
+    void testGetFrequency() {
+        InstalmentFrequencyType instalmentFrequencyType = InstalmentFrequencyType.F;
+        instalmentPaymentType.setFrequency(instalmentFrequencyType);
+
+        InstalmentFrequencyType actualInstalmentFrequencyType = instalmentPaymentType.getFrequency();
+
+        assertNotNull(actualInstalmentFrequencyType, "InstalmentPaymentType frequency should not be null");
+        assertEquals(instalmentFrequencyType.name(),
+                     actualInstalmentFrequencyType.name(),
+                     "InstalmentPaymentType has unexpected frequency");
+    }
+}

--- a/consumers/src/unit-test/java/uk/gov/moj/sdt/cmc/consumers/request/judgement/JudgementRequestTest.java
+++ b/consumers/src/unit-test/java/uk/gov/moj/sdt/cmc/consumers/request/judgement/JudgementRequestTest.java
@@ -1,0 +1,42 @@
+package uk.gov.moj.sdt.cmc.consumers.request.judgement;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.moj.sdt.cmc.consumers.request.common.SotSignature;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class JudgementRequestTest {
+
+    private static final String STATEMENT_OF_TRUTH_NAME = "Test SoT name";
+
+    private JudgementRequest judgementRequest;
+
+    @BeforeEach
+    void setUp() {
+        judgementRequest = new JudgementRequest();
+    }
+
+    @Test
+    void testGetSotName() {
+        SotSignature sotSignature = new SotSignature();
+        sotSignature.setName(STATEMENT_OF_TRUTH_NAME);
+
+        judgementRequest.setSotSignature(sotSignature);
+
+        assertEquals(STATEMENT_OF_TRUTH_NAME,
+                     judgementRequest.getSotName(),
+                     "JudgementRequest has unexpected statement of truth name");
+    }
+
+    @Test
+    void testGetSotNameNull() {
+        judgementRequest.setSotSignature(null);
+
+        String sotName = judgementRequest.getSotName();
+
+        assertNotNull(sotName, "JudgementRequest statement of truth name should not be null");
+        assertEquals("", sotName, "JudgmentRequest should have an empty string for statement of truth name");
+    }
+}

--- a/consumers/src/unit-test/java/uk/gov/moj/sdt/cmc/consumers/request/judgement/PaymentScheduleTest.java
+++ b/consumers/src/unit-test/java/uk/gov/moj/sdt/cmc/consumers/request/judgement/PaymentScheduleTest.java
@@ -1,0 +1,134 @@
+package uk.gov.moj.sdt.cmc.consumers.request.judgement;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PaymentScheduleTest {
+
+    private PaymentSchedule paymentSchedule;
+
+    @BeforeEach
+    void setup() {
+        paymentSchedule = new PaymentSchedule();
+    }
+
+    @Test
+    void testGetPaymentScheduleTypeFull() {
+        FullPaymentType fullPaymentType = new FullPaymentType();
+        paymentSchedule.setInFullByPayment(fullPaymentType);
+
+        String actualPaymentType = paymentSchedule.getPaymentScheduleType();
+
+        assertEquals(PaymentScheduleType.IN_FULL.getScheduleType(),
+                     actualPaymentType,
+                     "PaymentSchedule type should be in full");
+    }
+
+    @Test
+    void testGetPaymentScheduleTypeInstallment() {
+        InstalmentPaymentType instalmentPaymentType = new InstalmentPaymentType();
+        paymentSchedule.setInstalment(instalmentPaymentType);
+
+        String actualPaymentType = paymentSchedule.getPaymentScheduleType();
+
+        assertEquals(PaymentScheduleType.INSTALLMENT.getScheduleType(),
+                     actualPaymentType,
+                     "PaymentSchedule type should be installment");
+    }
+
+    @Test
+    void testGetPaymentScheduleTypeImmediate() {
+        ImmediatePaymentType immediatePaymentType = new ImmediatePaymentType();
+        paymentSchedule.setImmediatePayment(immediatePaymentType);
+
+        String actualPaymentType = paymentSchedule.getPaymentScheduleType();
+
+        assertEquals(PaymentScheduleType.IMMEDIATE.getScheduleType(),
+                     actualPaymentType,
+                     "PaymentSchedule type should be immediate");
+    }
+
+    @Test
+    void testGetPaymentInFullBy() {
+        LocalDateTime byLocalDateTime = LocalDateTime.of(2023, 1, 1, 0, 0);
+        FullPaymentType fullPaymentType = new FullPaymentType();
+        fullPaymentType.setFullByDate(Date.from(byLocalDateTime.atZone(ZoneId.systemDefault()).toInstant()));
+        paymentSchedule.setInFullByPayment(fullPaymentType);
+
+        Date actualDate = paymentSchedule.getPaymentInFullBy();
+
+        assertNotNull(actualDate, "PaymentSchedule payment in full by date should not be null");
+
+        LocalDateTime actualLocalDateTime = LocalDateTime.ofInstant(actualDate.toInstant(), ZoneId.systemDefault());
+        assertTrue(byLocalDateTime.isEqual(actualLocalDateTime), "Unexpected payment in full date");
+    }
+
+    @Test
+    void testGetPaymentInFullByNull() {
+        FullPaymentType fullPaymentType = new FullPaymentType();
+        fullPaymentType.setFullByDate(null);
+        paymentSchedule.setInFullByPayment(fullPaymentType);
+
+        Date actualDate = paymentSchedule.getPaymentInFullBy();
+
+        assertNull(actualDate, "PaymentSchedule payment in full by date should be null");
+    }
+
+    @Test
+    void testGetInstallmentAmount() {
+        Long amount = 3L;
+        InstalmentPaymentType instalmentPaymentType = new InstalmentPaymentType();
+        instalmentPaymentType.setAmount(amount);
+        paymentSchedule.setInstalment(instalmentPaymentType);
+
+        Long actualAmount = paymentSchedule.getInstallmentAmount();
+
+        assertNotNull(actualAmount, "PaymentSchedule installment amount should not be null");
+        assertEquals(amount, actualAmount, "Unexpected installment amount");
+    }
+
+    @Test
+    void testGetInstallmentAmountNull() {
+        InstalmentPaymentType instalmentPaymentType = new InstalmentPaymentType();
+        instalmentPaymentType.setAmount(null);
+        paymentSchedule.setInstalment(instalmentPaymentType);
+
+        Long actualAmount = paymentSchedule.getInstallmentAmount();
+
+        assertNull(actualAmount, "PaymentSchedule installment amount should be null");
+    }
+
+    @Test
+    void testGetInstallmentFrequency() {
+        InstalmentPaymentType instalmentPaymentType = new InstalmentPaymentType();
+        instalmentPaymentType.setFrequency(InstalmentFrequencyType.W);
+        paymentSchedule.setInstalment(instalmentPaymentType);
+
+        InstalmentFrequencyType actualInstalmentFrequency = paymentSchedule.getInstallmentFrequency();
+
+        assertNotNull(actualInstalmentFrequency, "PaymentSchedule instalment frequency should not be null");
+        assertEquals(InstalmentFrequencyType.W.name(),
+                     actualInstalmentFrequency.name(),
+                     "Unexpected installment frequency");
+    }
+
+    @Test
+    void testGetInstallmentFrequencyNull() {
+        InstalmentPaymentType instalmentPaymentType = new InstalmentPaymentType();
+        instalmentPaymentType.setFrequency(null);
+        paymentSchedule.setInstalment(instalmentPaymentType);
+
+        InstalmentFrequencyType actualInstalmentFrequency = paymentSchedule.getInstallmentFrequency();
+
+        assertNull(actualInstalmentFrequency, "PaymentSchedule instalment frequency should be null");
+    }
+}

--- a/consumers/src/unit-test/java/uk/gov/moj/sdt/cmc/consumers/response/JudgementWarrantResponseTest.java
+++ b/consumers/src/unit-test/java/uk/gov/moj/sdt/cmc/consumers/response/JudgementWarrantResponseTest.java
@@ -1,0 +1,37 @@
+package uk.gov.moj.sdt.cmc.consumers.response;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static uk.gov.moj.sdt.cmc.consumers.response.JudgmentWarrantStatus.WARRANT_REQUEST_ERROR;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class JudgementWarrantResponseTest {
+
+    private JudgementWarrantResponse judgementWarrantResponse;
+
+    @BeforeEach
+    void setup() {
+        judgementWarrantResponse = new JudgementWarrantResponse();
+    }
+
+    @Test
+    void testGetJudgementWarrantStatus() {
+        judgementWarrantResponse.setJudgmentWarrantStatus(WARRANT_REQUEST_ERROR);
+
+        assertEquals(WARRANT_REQUEST_ERROR.getMessage(),
+                     judgementWarrantResponse.getJudgmentWarrantStatus(),
+                     "JudgementWarrantResponse has unexpected judgement warrant status");
+    }
+
+    @Test
+    void testGetJudgmentWarrantStatusNull() {
+        judgementWarrantResponse.setJudgmentWarrantStatus(null);
+
+        assertNull(
+            judgementWarrantResponse.getJudgmentWarrantStatus(),
+            "JudgementWarrantResponse judgement warrant status should be null"
+        );
+    }
+}

--- a/consumers/src/unit-test/java/uk/gov/moj/sdt/config/AuthClientConfigurationTest.java
+++ b/consumers/src/unit-test/java/uk/gov/moj/sdt/config/AuthClientConfigurationTest.java
@@ -1,0 +1,57 @@
+package uk.gov.moj.sdt.config;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import uk.gov.hmcts.reform.authorisation.ServiceAuthorisationApi;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGeneratorFactory;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+
+public class AuthClientConfigurationTest {
+
+    private static final String S2S_AUTH_SECRET = "Test auth secret";
+    private static final String S2S_AUTH_MICROSERVICE = "Test auth microservice";
+
+    private AuthClientConfiguration authClientConfiguration;
+
+    @BeforeEach
+    void setUp() {
+        authClientConfiguration = new AuthClientConfiguration();
+    }
+
+    @Test
+    void testAuthTokenGenerator() {
+        try (
+            MockedStatic<AuthTokenGeneratorFactory> mockStaticAuthTokenGeneratorFactory =
+                mockStatic(AuthTokenGeneratorFactory.class)
+            ) {
+            ServiceAuthorisationApi mockServiceAuthorisationApi = mock(ServiceAuthorisationApi.class);
+            AuthTokenGenerator mockAuthTokenGenerator = mock(AuthTokenGenerator.class);
+
+            mockStaticAuthTokenGeneratorFactory.when(
+                () -> AuthTokenGeneratorFactory.createDefaultGenerator(S2S_AUTH_SECRET,
+                                                                       S2S_AUTH_MICROSERVICE,
+                                                                       mockServiceAuthorisationApi)
+            ).thenReturn(mockAuthTokenGenerator);
+
+            AuthTokenGenerator authTokenGenerator =
+                authClientConfiguration.authTokenGenerator(S2S_AUTH_SECRET,
+                                                           S2S_AUTH_MICROSERVICE,
+                                                           mockServiceAuthorisationApi);
+
+            assertNotNull(authTokenGenerator, "AuthTokenGenerator should not be null");
+            assertSame(mockAuthTokenGenerator, authTokenGenerator, "Unexpected AuthTokenGenerator object returned");
+
+            mockStaticAuthTokenGeneratorFactory.verify(
+                () -> AuthTokenGeneratorFactory.createDefaultGenerator(S2S_AUTH_SECRET,
+                                                                       S2S_AUTH_MICROSERVICE,
+                                                                       mockServiceAuthorisationApi)
+            );
+        }
+    }
+}

--- a/consumers/src/unit-test/java/uk/gov/moj/sdt/consumers/exception/XmlConversionExceptionTest.java
+++ b/consumers/src/unit-test/java/uk/gov/moj/sdt/consumers/exception/XmlConversionExceptionTest.java
@@ -1,0 +1,24 @@
+package uk.gov.moj.sdt.consumers.exception;
+
+import org.junit.jupiter.api.Test;
+
+import javax.xml.bind.JAXBException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class XmlConversionExceptionTest {
+
+    private static final String EXCEPTION_MESSAGE = "Test exception message";
+
+    @Test
+    void testConstructor() {
+        JAXBException jaxbException = new JAXBException(EXCEPTION_MESSAGE);
+
+        XmlConversionException xmlConversionException = new XmlConversionException(jaxbException);
+
+        String expectedExceptionMessage = JAXBException.class.getName() + ": " + EXCEPTION_MESSAGE;
+        assertEquals(expectedExceptionMessage,
+                     xmlConversionException.getMessage(),
+                     "XmlConversionException has unexpected exception message");
+    }
+}

--- a/consumers/src/unit-test/java/uk/gov/moj/sdt/idam/IdamRepositoryTest.java
+++ b/consumers/src/unit-test/java/uk/gov/moj/sdt/idam/IdamRepositoryTest.java
@@ -1,0 +1,90 @@
+package uk.gov.moj.sdt.idam;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.idam.client.IdamClient;
+import uk.gov.hmcts.reform.idam.client.models.UserDetails;
+import uk.gov.hmcts.reform.idam.client.models.UserInfo;
+import uk.gov.moj.sdt.params.ApplicationParams;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class IdamRepositoryTest {
+
+    private static final String BEARER_TOKEN = "Test bearer token";
+
+    private static final String SDT_SYSTEM_USER_ID = "Test SDT system user id";
+    private static final String SDT_SYSTEM_USER_PASSWORD = "Test SDT system user password";
+
+    private static final String SDT_SYSTEM_USER_ACCESS_TOKEN = "Test SDT system user access token";
+
+    private static final String USER_ID = "Test user id";
+
+    private IdamRepository idamRepository;
+
+    @Mock
+    private UserInfo mockUserInfo;
+
+    @Mock
+    private IdamClient mockIdamClient;
+
+    @Mock
+    private ApplicationParams mockApplicationParams;
+
+    @Mock
+    private UserDetails mockUserDetails;
+
+    @BeforeEach
+    void setUp() {
+        idamRepository = new IdamRepository(mockIdamClient, mockApplicationParams);
+    }
+
+    @Test
+    void testGetUserInfo() {
+        when(mockIdamClient.getUserInfo(BEARER_TOKEN)).thenReturn(mockUserInfo);
+
+        UserInfo userInfo = idamRepository.getUserInfo(BEARER_TOKEN);
+
+        assertNotNull(userInfo, "UserInfo should not be null");
+        assertSame(mockUserInfo, userInfo, "Unexpected UserInfo object returned");
+
+        verify(mockIdamClient).getUserInfo(BEARER_TOKEN);
+    }
+
+    @Test
+    void testGetSdtSystemUserAccessToken() {
+        when(mockApplicationParams.getSdtSystemUserId()).thenReturn(SDT_SYSTEM_USER_ID);
+        when(mockApplicationParams.getSdtSystemUserPassword()).thenReturn(SDT_SYSTEM_USER_PASSWORD);
+
+        when(mockIdamClient.getAccessToken(SDT_SYSTEM_USER_ID, SDT_SYSTEM_USER_PASSWORD))
+            .thenReturn(SDT_SYSTEM_USER_ACCESS_TOKEN);
+
+        String accessToken = idamRepository.getSdtSystemUserAccessToken();
+
+        assertEquals(SDT_SYSTEM_USER_ACCESS_TOKEN, accessToken, "Unexpected system access token returned");
+
+        verify(mockApplicationParams).getSdtSystemUserId();
+        verify(mockApplicationParams).getSdtSystemUserPassword();
+        verify(mockIdamClient).getAccessToken(SDT_SYSTEM_USER_ID, SDT_SYSTEM_USER_PASSWORD);
+    }
+
+    @Test
+    void testGetUserByUserId() {
+        when(mockIdamClient.getUserByUserId(BEARER_TOKEN, USER_ID)).thenReturn(mockUserDetails);
+
+        UserDetails userDetails = idamRepository.getUserByUserId(USER_ID, BEARER_TOKEN);
+
+        assertNotNull(userDetails, "UserDetails should not be null");
+        assertSame(mockUserDetails, userDetails, "Unexpected UserDetails object returned");
+
+        verify(mockIdamClient).getUserByUserId(BEARER_TOKEN, USER_ID);
+    }
+}

--- a/consumers/src/unit-test/java/uk/gov/moj/sdt/idam/S2SRepositoryTest.java
+++ b/consumers/src/unit-test/java/uk/gov/moj/sdt/idam/S2SRepositoryTest.java
@@ -1,0 +1,39 @@
+package uk.gov.moj.sdt.idam;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(MockitoExtension.class)
+class S2SRepositoryTest {
+
+    private static final String S2S_TOKEN = "Test S2S token";
+
+    private S2SRepository s2sRepository;
+
+    @Mock
+    AuthTokenGenerator mockAuthTokenGenerator;
+
+    @BeforeEach
+    void setUp() {
+        s2sRepository = new S2SRepository(mockAuthTokenGenerator);
+    }
+
+    @Test
+    void testGetS2SToken() {
+        when(mockAuthTokenGenerator.generate()).thenReturn(S2S_TOKEN);
+
+        String s2sToken = s2sRepository.getS2SToken();
+
+        assertEquals(S2S_TOKEN, s2sToken, "Unexpected S2S token returned");
+
+        verify(mockAuthTokenGenerator).generate();
+    }
+}

--- a/consumers/src/unit-test/java/uk/gov/moj/sdt/params/ApplicationParamsTest.java
+++ b/consumers/src/unit-test/java/uk/gov/moj/sdt/params/ApplicationParamsTest.java
@@ -1,0 +1,44 @@
+package uk.gov.moj.sdt.params;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.moj.sdt.utils.AbstractSdtUnitTestBase;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ApplicationParamsTest extends AbstractSdtUnitTestBase {
+
+    private static final String SDT_SYSTEM_USER_ID = "Test SDT system user id";
+    private static final String SDT_SYSTEM_USER_PASSWORD = "Test SDT system user password";
+
+    private ApplicationParams applicationParams;
+
+    @Override
+    protected void setUpLocalTests() {
+        applicationParams = new ApplicationParams();
+    }
+    @Test
+    void testGetSdtSystemUserId() {
+        setAccessibleField(ApplicationParams.class,
+                           "sdtSystemUserId",
+                           String.class,
+                           applicationParams,
+                           SDT_SYSTEM_USER_ID);
+
+        assertEquals(SDT_SYSTEM_USER_ID,
+                     applicationParams.getSdtSystemUserId(),
+                     "ApplicationParams has unexpected SDT system user id");
+    }
+
+    @Test
+    void testGetSdtSystemUserPassword() {
+        setAccessibleField(ApplicationParams.class,
+                           "sdtSystemUserPassword",
+                           String.class,
+                           applicationParams,
+                           SDT_SYSTEM_USER_PASSWORD);
+
+        assertEquals(SDT_SYSTEM_USER_PASSWORD,
+                     applicationParams.getSdtSystemUserPassword(),
+                     "ApplicationParams has unexpected SDT system user password");
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
SDT-138 (https://tools.hmcts.net/jira/browse/SDT-138)


### Change description ###
Added unit test classes to improve test coverage of consumers module.

Removed empty ClaimStatusUpdateRequestServiceTest.java file.  No corresponding class for this test class - may have been intended to test ClaimStatusUpdateService class for which there is already a test class.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
