### PR TITLE
Fix CVE-2023-39533

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -225,7 +225,7 @@ allprojects {
     implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.10'
     implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.2.10'
     implementation group: 'com.azure', name: 'azure-core', version: '1.13.0'
-    implementation group: 'com.azure', name: 'azure-messaging-servicebus', version: '7.0.2'
+    implementation group: 'com.azure', name: 'azure-messaging-servicebus', version: '7.14.3'
     implementation group: 'com.fasterxml.jackson.module', name: 'jackson-module-jaxb-annotations', version: '2.10.3'
     implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: '6.0.1'
     implementation 'com.google.guava:guava:32.0.1-jre'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -21,12 +21,12 @@
   <!--End of false positives section -->
 
   <!--Please add all the temporary suppression under the below section-->
+  <!--
   <suppress>
     <notes>Temporary Suppressions
-      CVE-2023-39533
     </notes>
-    <cve>CVE-2023-39533</cve>
   </suppress>
+  -->
   <!--End of temporary suppression section -->
 
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
Updated azure-messaging-servicebus dependency to version 7.14.3.  This version does not have a dependency on the libraries affected by CVE-2023-39533.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
