### PR TITLE
SDT-178: Ensure SDT uses servicebus

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -165,7 +165,6 @@ ext {
   tomcatVersion = '9.0.82'
   cxfVersion = '3.6.2'
   jaxwsVersion = "2.3.1"
-  activeMQVersion = '5.18.3'
   testcontainers = '1.19.1'
   sdtCommonVersion = '1.1.0-SDT-149.0.1'
   limits = [
@@ -194,6 +193,7 @@ ext['guava.version'] = '30.0-jre'
 ext['apache.poi.version'] = '4.1.0'
 ext['snakeyaml.version'] = '1.33'
 ext['hibernate-validator.version'] = '6.0.20.Final'
+ext['activemq.version'] = '5.18.3'
 
 dependencyManagement {
   imports {
@@ -249,8 +249,6 @@ allprojects {
     implementation group: 'javax.inject', name: 'javax.inject', version: '1'
     implementation group: 'javax.jws', name: 'javax.jws-api', version: '1.1'
     implementation group: 'net.minidev', name: 'json-smart', version: '2.5.0'
-    implementation group: 'org.apache.activemq', name: 'activemq-broker', version: activeMQVersion
-    implementation group: 'org.apache.activemq', name: 'activemq-client', version: activeMQVersion
     implementation group: 'org.apache.commons', name: 'commons-compress', version: '1.24.0'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.13.0'
     implementation group: 'org.apache.cxf', name: 'cxf-rt-features-logging', version: cxfVersion
@@ -269,12 +267,10 @@ allprojects {
     implementation group: 'org.postgresql', name: 'postgresql', version: postgresqlVersion
     implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: '1.7.0'
     implementation group: 'org.springframework', name: 'spring-jms'
-    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-activemq'
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-actuator'
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-aop'
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-cache'
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-data-jpa'
-    implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: '4.0.4'
     implementation(group: 'org.springframework.boot', name: 'spring-boot-starter-jdbc') {
       exclude group: 'org.apache.tomcat', module: 'tomcat-jdbc'
     }
@@ -329,6 +325,7 @@ allprojects {
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: junitVersion
     testImplementation group: 'org.mockito', name: 'mockito-inline', version: '3.12.4'
     testImplementation group: 'org.postgresql', name: 'postgresql', version: postgresqlVersion
+    testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-activemq'
     testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', {
       exclude group: 'junit', module: 'junit'
       exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'

--- a/build.gradle
+++ b/build.gradle
@@ -227,6 +227,13 @@ allprojects {
     implementation group: 'com.fasterxml.jackson.module', name: 'jackson-module-jaxb-annotations', version: '2.15.3'
     implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: '6.0.1'
     implementation 'com.google.guava:guava:32.1.3-jre'
+    implementation group: 'com.azure.spring', name: 'spring-cloud-azure-starter-servicebus-jms', version: '4.12.0'
+    implementation group: 'com.azure', name: 'azure-identity-extensions'
+    constraints {
+      implementation(group: 'com.azure', name: 'azure-identity-extensions', version: '1.1.9') {
+        because 'CVE-2023-36414 and CVE-2023-36415 from dependency in com.azure.spring:spring-cloud-azure-starter-servicebus-jms:4.12.0'
+      }
+    }
     implementation group: 'com.sun.xml.ws', name: 'jaxws-ri', version: '3.0.2'
     implementation group: 'com.vladmihalcea', name: 'hibernate-types-52', version: '2.21.1'
     implementation group: 'com.zaxxer', name: 'HikariCP', version: '4.0.3'

--- a/charts/civil-sdt/Chart.yaml
+++ b/charts/civil-sdt/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for civil-sdt app
 name: civil-sdt
 home: https://github.com/hmcts/civil-sdt
-version: 0.0.19
+version: 0.0.20
 maintainers:
   - name: HMCTS SDT team
 dependencies:

--- a/charts/civil-sdt/values.yaml
+++ b/charts/civil-sdt/values.yaml
@@ -30,5 +30,7 @@ java:
           alias: SDT_DB_HOST
         - name: civil-sdt-servicebus-connection-string
           alias: CIVIL_SDT_SERVICEBUS_CONNECTION_STRING
+        - name: civil-sdt-servicebus-pricing-tier
+          alias: CIVIL_SDT_SERVICEBUS_PRICING_TIER
 servicebus:
   enabled: false

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -24,8 +24,12 @@
   <suppress>
     <notes>Temporary Suppressions
       CVE-2023-4586
+      CVE-2023-36414 - Still flagged despite azure-identity-extensions dependency constraint
+      CVE-2023-36415 - Still flagged despite azure-identity-extensions dependency constraint
     </notes>
     <cve>CVE-2023-4586</cve>
+    <cve>CVE-2023-36414</cve>
+    <cve>CVE-2023-36415</cve>
   </suppress>
   <!--End of temporary suppression section -->
 

--- a/infrastructure/service-bus.tf
+++ b/infrastructure/service-bus.tf
@@ -32,3 +32,9 @@ resource "azurerm_key_vault_secret" "servicebus_primary_shared_access_key" {
   value        = module.servicebus-namespace.primary_send_and_listen_shared_access_key
   key_vault_id = module.civil_sdt_key_vault.key_vault_id
 }
+
+resource "azurerm_key_vault_secret" "servicebus-pricing-tier" {
+  name         = "civil-sdt-servicebus-pricing-tier"
+  value        = var.sku
+  key_vault_id = module.civil_sdt_key_vault.key_vault_id
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -59,9 +59,6 @@ spring:
     baseline-version: '0001'
     out-of-order: 'true'
     baseline-on-migrate: 'true'
-  activemq:
-    packages:
-      trusted: uk.gov.moj.sdt.services.messaging
 
 sdt:
   tx-timeout:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -18,6 +18,7 @@ spring:
   jms:
     servicebus:
       connection-string: ${CIVIL_SDT_SERVICEBUS_CONNECTION_STRING:Endpoint=sb://destination1.servicebus.windows.net;SharedAccessKeyName=[KEYNAME];SharedAccessKey=[KEY]}
+      pricing-tier: ${CIVIL_SDT_SERVICEBUS_PRICING_TIER:Standard}
       internal:
         targetAppQueue:
           MCOL: ${CIVIL_SDT_QUEUE}


### PR DESCRIPTION
### JIRA link (if applicable) ###
SDT-178 (https://tools.hmcts.net/jira/browse/SDT-178)


### Change description ###
- Added spring-cloud-azure-starter-servicebus-jms depedency to build.gradle.  This replaces azure-servicebus-jms-spring-boot-starter.  Also added a constraint which should resolve CVE-2023-36414 and CVE-2023-36415, but these are still being flagged by DependencyCheck.  Added suppressions back to suppressions.xml until this is sorted out.
- Removed activemq-broker and activemq-client dependencies from build.gradle.  These are automatically included by spring-boot-starter-activemq.  Replaced activeMQVersion property with spring boot activemq.version property to set ActiveMQ version.
- Changed spring-boot-starter-activemq dependency to a test dependency and moved it to test dependency section.
- Removed duplicate spring-cloud-starter-openfeign dependency.
- Removed activemq.packages.trusted property from application.yaml.  ActiveMQ configuration not required as application should use servicebus.
- Added new pricing tier secret to servicebus.tf.  This is used to set spring.jms.servicebus.pricing-tier property which is needed by spring-cloud-azure-starter-servicebus-jms.
- Added environment variable to hold pricing tier secret to values.yaml
- Added spring.jms.servicebus.pricing-tier property to application.yaml.




**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
