### PR TITLE
Fix Fortify scan issue

### DIFF
--- a/config/fortify-client.properties
+++ b/config/fortify-client.properties
@@ -1,2 +1,2 @@
 fortify.client.releaseId=115830
-fortify.exclude.pattern=*.jar|*.zip|*.tar|*.key|*.lock|*.html|/build|/.gradle|/.git|/node_modules|/test|/dist|/functionalTest|/integrationTest|/integ-test|/unit-test|/end-to-end-test
+fortify.exclude.pattern=*.jar|*.zip|*.tar|*.key|*.lock|*.html|/build|/.gradle|/.git|/node_modules|/test|/dist|/functionalTest|/integrationTest|/integ-test|/unit-test|/end-to-end-test|/scripts/legacy-db-migration


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
Exclude /scripts/legacy-db-migration directory from zip file created for Fortify scan.  The data_migration_validation.sql file under this directory causes the Fortify scan to run out of memory and fail.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
