### PR TITLE
Remove log4j-to-slf4j exclusions from civil-sdt build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -348,9 +348,6 @@ allprojects {
   }
 
   configurations.configureEach {
-    collect { configuration ->
-      configuration.exclude group: 'org.apache.logging.log4j', module: 'log4j-to-slf4j'
-    }
     resolutionStrategy {
       eachDependency { details ->
         if (details.requested.group == 'com.github.ben-manes.caffeine' && details.requested.name == 'caffeine') {
@@ -438,9 +435,6 @@ subprojects { subproject ->
   }
 
   configurations.configureEach {
-    collect { configuration ->
-      configuration.exclude group: 'org.apache.logging.log4j', module: 'log4j-to-slf4j'
-    }
     exclude group: 'org.springframework.security', module: 'spring-security-rsa'
   }
 


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SDT-193

### Change description ###

The log4j-to-slf4j exclusions are no longer needed following the removal of the log4j-core dependency

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
