### PR TITLE
SDT-218

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -704,8 +704,6 @@ tasks.register('fortifyScan', JavaExec) {
   mainClass = "uk.gov.hmcts.fortifyclient.FortifyClientMainApp"
   classpath += sourceSets.test.runtimeClasspath
   jvmArgs = ['--add-opens=java.base/java.lang.reflect=ALL-UNNAMED']
-  // The line below prevents the build from failing if the Fortify scan detects issues
-  ignoreExitValue = true
 }
 
 cucumberReports {


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SDT-218

### Change description ###

Removing the line 'ignoreExitValue = true' from the fortifyScan task in the civil-sdt build.gradle file. This code was needed previously to prevent build failures if Fortify scan detects issues, but is no longer needed 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
