### PR TITLE
SDT-231: Rework integration with service bus

### DIFF
--- a/dao/src/integ-test/resources/application-integ.yaml
+++ b/dao/src/integ-test/resources/application-integ.yaml
@@ -7,6 +7,9 @@ spring:
       enabled: false
   jms:
     servicebus:
+      idle-timeout: ${QUEUE_TIME_OUT:900000}
+      connection-string: ${CIVIL_SDT_SERVICEBUS_CONNECTION_STRING:Endpoint=sb://destination1.servicebus.windows.net;SharedAccessKeyName=[KEYNAME];SharedAccessKey=[KEY]}
+      pricing-tier: ${CIVIL_SDT_SERVICEBUS_PRICING_TIER:Standard}
       internal:
         targetAppQueue:
           MCOL: ${CIVIL_SDT_QUEUE}

--- a/services/src/integ-test/java/uk/gov/moj/sdt/services/BulkFeedbackServiceIntTest.java
+++ b/services/src/integ-test/java/uk/gov/moj/sdt/services/BulkFeedbackServiceIntTest.java
@@ -17,6 +17,7 @@ import uk.gov.moj.sdt.domain.api.IBulkFeedbackRequest;
 import uk.gov.moj.sdt.domain.api.IBulkSubmission;
 import uk.gov.moj.sdt.domain.api.IIndividualRequest;
 import uk.gov.moj.sdt.services.api.IBulkFeedbackService;
+import uk.gov.moj.sdt.services.config.ConnectionFactoryTestConfig;
 import uk.gov.moj.sdt.services.config.ServicesTestConfig;
 import uk.gov.moj.sdt.test.utils.AbstractIntegrationTest;
 import uk.gov.moj.sdt.test.utils.TestConfig;
@@ -33,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 @ActiveProfiles("integ")
 @ExtendWith(SpringExtension.class)
-@SpringBootTest(classes = {TestConfig.class, ServicesTestConfig.class})
+@SpringBootTest(classes = {TestConfig.class, ServicesTestConfig.class, ConnectionFactoryTestConfig.class})
 @Sql(scripts = {"classpath:uk/gov/moj/sdt/services/sql/RefData.sql",
     "classpath:uk/gov/moj/sdt/services/sql/BulkFeedbackServiceIntTest.sql"})
 @Transactional

--- a/services/src/integ-test/java/uk/gov/moj/sdt/services/BulkSubmissionServiceIntTest.java
+++ b/services/src/integ-test/java/uk/gov/moj/sdt/services/BulkSubmissionServiceIntTest.java
@@ -51,6 +51,7 @@ import uk.gov.moj.sdt.domain.api.IIndividualRequest;
 import uk.gov.moj.sdt.domain.api.IServiceRouting;
 import uk.gov.moj.sdt.domain.api.IServiceType;
 import uk.gov.moj.sdt.domain.api.ITargetApplication;
+import uk.gov.moj.sdt.services.config.ConnectionFactoryTestConfig;
 import uk.gov.moj.sdt.services.config.ServicesTestConfig;
 import uk.gov.moj.sdt.test.utils.AbstractIntegrationTest;
 import uk.gov.moj.sdt.test.utils.TestConfig;
@@ -79,7 +80,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  */
 @ActiveProfiles("integ")
 @ExtendWith(SpringExtension.class)
-@SpringBootTest(classes = {TestConfig.class, ServicesTestConfig.class })
+@SpringBootTest(classes = {TestConfig.class, ServicesTestConfig.class, ConnectionFactoryTestConfig.class})
 @Sql(scripts = {"classpath:uk/gov/moj/sdt/services/sql/RefData.sql", "classpath:uk/gov/moj/sdt/services/sql/BulkSubmissionServiceIntTest.sql"})
 @Transactional
 public class BulkSubmissionServiceIntTest extends AbstractIntegrationTest {

--- a/services/src/integ-test/java/uk/gov/moj/sdt/services/SubmitQueryServiceIntTest.java
+++ b/services/src/integ-test/java/uk/gov/moj/sdt/services/SubmitQueryServiceIntTest.java
@@ -51,6 +51,7 @@ import uk.gov.moj.sdt.domain.api.IServiceRouting;
 import uk.gov.moj.sdt.domain.api.IServiceType;
 import uk.gov.moj.sdt.domain.api.ISubmitQueryRequest;
 import uk.gov.moj.sdt.domain.api.ITargetApplication;
+import uk.gov.moj.sdt.services.config.ConnectionFactoryTestConfig;
 import uk.gov.moj.sdt.services.config.ServicesTestConfig;
 import uk.gov.moj.sdt.test.utils.AbstractIntegrationTest;
 import uk.gov.moj.sdt.test.utils.TestConfig;
@@ -73,7 +74,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 @ActiveProfiles("integ")
 @ExtendWith(SpringExtension.class)
-@SpringBootTest(classes = {TestConfig.class, ServicesTestConfig.class, ConsumersTestConfig.class, DaoTestConfig.class})
+@SpringBootTest(classes = {TestConfig.class, ServicesTestConfig.class, ConsumersTestConfig.class, DaoTestConfig.class, ConnectionFactoryTestConfig.class})
 @Sql(scripts = {"classpath:uk/gov/moj/sdt/services/sql/RefData.sql", "classpath:uk/gov/moj/sdt/services/sql/SubmitQueryServiceIntTest.sql"})
 public class SubmitQueryServiceIntTest extends AbstractIntegrationTest {
 

--- a/services/src/integ-test/java/uk/gov/moj/sdt/services/UpdateRequestServiceIntTest.java
+++ b/services/src/integ-test/java/uk/gov/moj/sdt/services/UpdateRequestServiceIntTest.java
@@ -18,6 +18,7 @@ import uk.gov.moj.sdt.domain.IndividualRequest;
 import uk.gov.moj.sdt.domain.api.IBulkSubmission;
 import uk.gov.moj.sdt.domain.api.IErrorLog;
 import uk.gov.moj.sdt.domain.api.IIndividualRequest;
+import uk.gov.moj.sdt.services.config.ConnectionFactoryTestConfig;
 import uk.gov.moj.sdt.services.config.ServicesTestConfig;
 import uk.gov.moj.sdt.test.utils.AbstractIntegrationTest;
 import uk.gov.moj.sdt.test.utils.TestConfig;
@@ -34,7 +35,7 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 @ActiveProfiles("integ")
 @ExtendWith(SpringExtension.class)
-@SpringBootTest(classes = {TestConfig.class, ServicesTestConfig.class, DaoTestConfig.class})
+@SpringBootTest(classes = {TestConfig.class, ServicesTestConfig.class, DaoTestConfig.class, ConnectionFactoryTestConfig.class})
 @Sql(scripts = {"classpath:uk/gov/moj/sdt/services/sql/RefData.sql",
     "classpath:uk/gov/moj/sdt/services/sql/UpdateRequestServiceIntTest.sql"})
 @Transactional

--- a/services/src/integ-test/java/uk/gov/moj/sdt/services/cache/GlobalParametersCacheIntTest.java
+++ b/services/src/integ-test/java/uk/gov/moj/sdt/services/cache/GlobalParametersCacheIntTest.java
@@ -42,6 +42,7 @@ import org.springframework.transaction.annotation.Transactional;
 import uk.gov.moj.sdt.dao.GlobalParametersDao;
 import uk.gov.moj.sdt.domain.api.IGlobalParameter;
 import uk.gov.moj.sdt.domain.cache.api.ICacheable;
+import uk.gov.moj.sdt.services.config.ConnectionFactoryTestConfig;
 import uk.gov.moj.sdt.services.config.ServicesTestConfig;
 import uk.gov.moj.sdt.test.utils.AbstractIntegrationTest;
 import uk.gov.moj.sdt.test.utils.TestConfig;
@@ -58,7 +59,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
  */
 @ActiveProfiles("integ")
 @ExtendWith(SpringExtension.class)
-@SpringBootTest(classes = {TestConfig.class, ServicesTestConfig.class})
+@SpringBootTest(classes = {TestConfig.class, ServicesTestConfig.class, ConnectionFactoryTestConfig.class})
 @Sql(scripts = {"classpath:uk/gov/moj/sdt/services/sql/RefData.sql", "classpath:uk/gov/moj/sdt/services/sql/GlobalParametersCacheIntTest.sql"})
 @Transactional
 public class GlobalParametersCacheIntTest extends AbstractIntegrationTest {

--- a/services/src/integ-test/java/uk/gov/moj/sdt/services/config/ConnectionFactoryTestConfig.java
+++ b/services/src/integ-test/java/uk/gov/moj/sdt/services/config/ConnectionFactoryTestConfig.java
@@ -1,0 +1,29 @@
+package uk.gov.moj.sdt.services.config;
+
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.jms.connection.CachingConnectionFactory;
+
+import javax.jms.ConnectionFactory;
+import java.util.ArrayList;
+
+@TestConfiguration
+public class ConnectionFactoryTestConfig {
+
+    @Bean
+    public ConnectionFactory connectionFactory() {
+        CachingConnectionFactory cachingConnectionFactory = new CachingConnectionFactory();
+
+        ActiveMQConnectionFactory activeMQConnectionFactory = new ActiveMQConnectionFactory();
+        activeMQConnectionFactory.setBrokerURL("vm://localhost?broker.persistent=false");
+
+        ArrayList<String> trustedPackages = new ArrayList<>();
+        trustedPackages.add("uk.gov.moj.sdt.services.messaging");
+        activeMQConnectionFactory.setTrustedPackages(trustedPackages);
+
+        cachingConnectionFactory.setTargetConnectionFactory(activeMQConnectionFactory);
+
+        return cachingConnectionFactory;
+    }
+}

--- a/services/src/integ-test/java/uk/gov/moj/sdt/services/messaging/IndividualRequestMdbIntTest.java
+++ b/services/src/integ-test/java/uk/gov/moj/sdt/services/messaging/IndividualRequestMdbIntTest.java
@@ -43,6 +43,7 @@ import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.moj.sdt.services.api.ITargetApplicationSubmissionService;
+import uk.gov.moj.sdt.services.config.ConnectionFactoryTestConfig;
 import uk.gov.moj.sdt.services.config.ServicesTestConfig;
 import uk.gov.moj.sdt.test.utils.AbstractIntegrationTest;
 import uk.gov.moj.sdt.test.utils.TestConfig;
@@ -62,7 +63,7 @@ import static org.mockito.Mockito.when;
  */
 @ActiveProfiles("integ")
 @ExtendWith(SpringExtension.class)
-@SpringBootTest(classes = {TestConfig.class, ServicesTestConfig.class})
+@SpringBootTest(classes = {TestConfig.class, ServicesTestConfig.class, ConnectionFactoryTestConfig.class})
 @Sql(scripts = {"classpath:uk/gov/moj/sdt/services/sql/RefData.sql", "classpath:uk/gov/moj/sdt/services/sql/IndividualRequestMdbIntTest.sql"})
 @Transactional
 public class IndividualRequestMdbIntTest extends AbstractIntegrationTest {

--- a/services/src/integ-test/java/uk/gov/moj/sdt/services/messaging/MessageWriterIntAsbTest.java
+++ b/services/src/integ-test/java/uk/gov/moj/sdt/services/messaging/MessageWriterIntAsbTest.java
@@ -40,6 +40,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jms.core.JmsTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.moj.sdt.services.config.ConnectionFactoryTestConfig;
 import uk.gov.moj.sdt.services.config.ServicesTestConfig;
 import uk.gov.moj.sdt.services.messaging.api.ISdtMessage;
 import uk.gov.moj.sdt.test.utils.AbstractIntegrationTest;
@@ -62,7 +63,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 @ActiveProfiles("integ-asb")
 @ExtendWith(SpringExtension.class)
-@SpringBootTest(classes = {TestConfig.class, ServicesTestConfig.class})
+@SpringBootTest(classes = {TestConfig.class, ServicesTestConfig.class, ConnectionFactoryTestConfig.class})
 @Disabled("Preview environments don't support Azure Service bus queues")
 class MessageWriterIntAsbTest extends AbstractIntegrationTest {
 

--- a/services/src/integ-test/java/uk/gov/moj/sdt/services/messaging/MessageWriterIntTest.java
+++ b/services/src/integ-test/java/uk/gov/moj/sdt/services/messaging/MessageWriterIntTest.java
@@ -38,6 +38,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jms.core.JmsTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.moj.sdt.services.config.ConnectionFactoryTestConfig;
 import uk.gov.moj.sdt.services.config.ServicesTestConfig;
 import uk.gov.moj.sdt.services.messaging.api.ISdtMessage;
 import uk.gov.moj.sdt.test.utils.AbstractIntegrationTest;
@@ -59,7 +60,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 @ActiveProfiles("integ")
 @ExtendWith(SpringExtension.class)
-@SpringBootTest(classes = {TestConfig.class, ServicesTestConfig.class})
+@SpringBootTest(classes = {TestConfig.class, ServicesTestConfig.class, ConnectionFactoryTestConfig.class})
 class MessageWriterIntTest extends AbstractIntegrationTest {
 
     private static final String TARGET_APP_CODE = "TEST1";

--- a/services/src/integ-test/java/uk/gov/moj/sdt/services/utils/SdtBulkReferenceGeneratorIntTest.java
+++ b/services/src/integ-test/java/uk/gov/moj/sdt/services/utils/SdtBulkReferenceGeneratorIntTest.java
@@ -41,6 +41,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
+import uk.gov.moj.sdt.services.config.ConnectionFactoryTestConfig;
 import uk.gov.moj.sdt.services.config.ServicesTestConfig;
 import uk.gov.moj.sdt.services.utils.api.ISdtBulkReferenceGenerator;
 import uk.gov.moj.sdt.test.utils.AbstractIntegrationTest;
@@ -57,7 +58,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 @ActiveProfiles("integ")
 @ExtendWith(SpringExtension.class)
-@SpringBootTest(classes = {TestConfig.class, ServicesTestConfig.class })
+@SpringBootTest(classes = {TestConfig.class, ServicesTestConfig.class, ConnectionFactoryTestConfig.class})
 @Sql(scripts = {"classpath:uk/gov/moj/sdt/services/sql/RefData.sql", "classpath:uk/gov/moj/sdt/services/sql/SubmitQueryServiceIntTest.sql"})
 @Transactional
 public class SdtBulkReferenceGeneratorIntTest extends AbstractIntegrationTest {

--- a/services/src/integ-test/resources/application-integ.yaml
+++ b/services/src/integ-test/resources/application-integ.yaml
@@ -12,7 +12,9 @@ spring:
           MCOL: ${CIVIL_SDT_QUEUE:McolQueue}
           MCOLS: ${CIVIL_SDT_QUEUE:McolsQueue}
           TEST1: ${CIVIL_SDT_QUEUE:Test1Queue}
+      idle-timeout: ${QUEUE_TIME_OUT:900000}
       connection-string: ${CIVIL_SDT_SERVICEBUS_CONNECTION_STRING:Endpoint=sb://destination1.servicebus.windows.net;SharedAccessKeyName=[KEYNAME];SharedAccessKey=[KEY]}
+      pricing-tier: ${CIVIL_SDT_SERVICEBUS_PRICING_TIER:Standard}
       enabled: false
 
   aop:

--- a/services/src/main/java/uk/gov/moj/sdt/services/config/ConnectionFactoryConfig.java
+++ b/services/src/main/java/uk/gov/moj/sdt/services/config/ConnectionFactoryConfig.java
@@ -1,0 +1,72 @@
+package uk.gov.moj.sdt.services.config;
+
+import com.microsoft.azure.servicebus.jms.ConnectionStringBuilder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.qpid.jms.JmsConnectionFactory;
+import org.apache.qpid.jms.policy.JmsDefaultPrefetchPolicy;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jms.connection.CachingConnectionFactory;
+
+import javax.jms.ConnectionFactory;
+
+/**
+ * Configures a connection factory to use with the service bus.
+ *
+ * Unable to use connection factory created by Spring auto-configuration as this has
+ * issues with the mechanism used by the application to send messages to the service bus.
+ */
+@Configuration
+@Getter
+@Setter
+@Slf4j
+public class ConnectionFactoryConfig {
+
+    @Value("${spring.jms.servicebus.connection-string}")
+    private String connectionString;
+
+    @Value("${spring.jms.servicebus.idle-timeout}")
+    private int idleTimeout;
+
+    @Bean
+    public ConnectionFactory connectionFactory() {
+        log.debug("Creating CachingConnectionFactory to use with service bus");
+
+        CachingConnectionFactory cachingConnectionFactory = new CachingConnectionFactory();
+
+        // Use ConnectionStringBuilder to parse the connection string
+        ConnectionStringBuilder connectionStringBuilder = new ConnectionStringBuilder(connectionString);
+
+        String remoteUri =
+            "failover:(amqps://" + connectionStringBuilder.getEndpoint().getHost()
+                + "?amqp.idleTimeout=" + idleTimeout + ")";
+        String username = connectionStringBuilder.getSasKeyName();
+        String password = connectionStringBuilder.getSasKey();
+
+        JmsConnectionFactory jmsConnectionFactory = createJmsConnectionFactory(remoteUri, username, password);
+        cachingConnectionFactory.setTargetConnectionFactory(jmsConnectionFactory);
+
+        return cachingConnectionFactory;
+    }
+
+    private JmsConnectionFactory createJmsConnectionFactory(String remoteUri, String username, String password) {
+        log.debug("Creating JmsConnectionFactory for remoteUri [{}]", remoteUri);
+
+        JmsConnectionFactory jmsConnectionFactory = new JmsConnectionFactory();
+
+        jmsConnectionFactory.setRemoteURI(remoteUri);
+        jmsConnectionFactory.setUsername(username);
+        jmsConnectionFactory.setPassword(password);
+
+        // Set all prefetch policy values to zero
+        JmsDefaultPrefetchPolicy jmsDefaultPrefetchPolicy =
+            (JmsDefaultPrefetchPolicy) jmsConnectionFactory.getPrefetchPolicy();
+        jmsDefaultPrefetchPolicy.setAll(0);
+        jmsConnectionFactory.setPrefetchPolicy(jmsDefaultPrefetchPolicy);
+
+        return jmsConnectionFactory;
+    }
+}

--- a/services/src/main/java/uk/gov/moj/sdt/services/messaging/JmsTemplateConfig.java
+++ b/services/src/main/java/uk/gov/moj/sdt/services/messaging/JmsTemplateConfig.java
@@ -1,6 +1,5 @@
 package uk.gov.moj.sdt.services.messaging;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jms.core.JmsTemplate;
@@ -8,9 +7,7 @@ import org.springframework.jms.core.JmsTemplate;
 import javax.jms.ConnectionFactory;
 import javax.jms.Session;
 
-
 @Configuration
-@ConditionalOnProperty("enable-jms")
 public class JmsTemplateConfig {
 
     @Bean

--- a/services/src/main/java/uk/gov/moj/sdt/services/messaging/MessageWriter.java
+++ b/services/src/main/java/uk/gov/moj/sdt/services/messaging/MessageWriter.java
@@ -34,7 +34,6 @@ package uk.gov.moj.sdt.services.messaging;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jms.IllegalStateException;
 import org.springframework.jms.UncategorizedJmsException;
 import org.springframework.jms.connection.CachingConnectionFactory;
@@ -72,9 +71,6 @@ public class MessageWriter implements IMessageWriter {
 
     private final QueueConfig queueConfig;
 
-    @Value("${enable-queue-reset:false}")
-    private boolean enableQueueReset;
-
     /**
      * Creates a message sender with the JmsTemplate.
      *
@@ -106,14 +102,6 @@ public class MessageWriter implements IMessageWriter {
         SdtMetricsMBean.getMetrics().upRequestQueueLength();
 
         try {
-            if (enableQueueReset) {
-                LOGGER.debug("Resetting queue connection");
-                CachingConnectionFactory cachingConnectionFactory =
-                    (CachingConnectionFactory) this.jmsTemplate.getConnectionFactory();
-                if (cachingConnectionFactory != null) {
-                    cachingConnectionFactory.resetConnection();
-                }
-            }
             this.jmsTemplate.convertAndSend(queueName, sdtMessage);
             LOGGER.debug("jmsTemplate.convertAndSend() completed for [{}]", sdtMessage.getSdtRequestReference());
         } catch (final IllegalStateException e) {

--- a/services/src/main/java/uk/gov/moj/sdt/services/utils/MessagingUtility.java
+++ b/services/src/main/java/uk/gov/moj/sdt/services/utils/MessagingUtility.java
@@ -66,9 +66,6 @@ public class MessagingUtility implements IMessagingUtility {
     @Value("${sdt.service.config.queue_delay:500}")
     private int queueDelay;
 
-    @Value("${enable-single-executor:false}")
-    private boolean enableSingleExecutor;
-
     private ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
 
     @Autowired
@@ -80,16 +77,7 @@ public class MessagingUtility implements IMessagingUtility {
     @Override
     public void enqueueRequest(final IIndividualRequest individualRequest) {
         LOGGER.debug("enqueueRequest: [{}]", individualRequest.getSdtRequestReference());
-        if (enableSingleExecutor) {
-            executorService.schedule(() -> {
-                LOGGER.debug("enqueueRequests: executorService (single)");
-                queueRequest(individualRequest);
-                }
-                , queueDelay, TimeUnit.MILLISECONDS
-            );
-        } else {
-            queueRequest(individualRequest);
-        }
+        queueRequest(individualRequest);
     }
 
     @Override

--- a/services/src/main/java/uk/gov/moj/sdt/services/utils/RequeueIndividualRequestUtility.java
+++ b/services/src/main/java/uk/gov/moj/sdt/services/utils/RequeueIndividualRequestUtility.java
@@ -1,0 +1,40 @@
+package uk.gov.moj.sdt.services.utils;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import uk.gov.moj.sdt.dao.api.IIndividualRequestDao;
+import uk.gov.moj.sdt.domain.api.IIndividualRequest;
+import uk.gov.moj.sdt.services.utils.api.IMessagingUtility;
+
+@Component("requeueIndividualRequestUtility")
+@Slf4j
+public class RequeueIndividualRequestUtility {
+
+    private final IIndividualRequestDao individualRequestDao;
+
+    private final IMessagingUtility messagingUtility;
+
+    @Autowired
+    public RequeueIndividualRequestUtility(IIndividualRequestDao individualRequestDao,
+                                           IMessagingUtility messagingUtility) {
+        this.individualRequestDao = individualRequestDao;
+        this.messagingUtility = messagingUtility;
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void requeueIndividualRequest(IIndividualRequest individualRequest) {
+        log.debug("Re-queue pending individual request [{}]", individualRequest.getSdtRequestReference());
+        individualRequest.setDeadLetter(false);
+
+        messagingUtility.enqueueRequest(individualRequest);
+
+        // Re-set the forwarding attempts on the individual request.
+        individualRequest.resetForwardingAttempts();
+
+        // Persist the individual request.
+        individualRequestDao.persist(individualRequest);
+    }
+}

--- a/services/src/unit-test/java/uk/gov/moj/sdt/services/config/ConnectionFactoryConfigTest.java
+++ b/services/src/unit-test/java/uk/gov/moj/sdt/services/config/ConnectionFactoryConfigTest.java
@@ -1,0 +1,68 @@
+package uk.gov.moj.sdt.services.config;
+
+import org.apache.qpid.jms.JmsConnectionFactory;
+import org.apache.qpid.jms.policy.JmsDefaultPrefetchPolicy;
+import org.junit.jupiter.api.Test;
+import org.springframework.jms.connection.CachingConnectionFactory;
+import uk.gov.moj.sdt.utils.AbstractSdtUnitTestBase;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ConnectionFactoryConfigTest extends AbstractSdtUnitTestBase {
+
+    private static final String SERVICE_BUS_HOST = "destination1.servicebus.windows.net";
+    private static final String SERVICE_BUS_ACCESS_KEY_NAME = "[KEYNAME]";
+    private static final String SERVICE_BUS_ACCESS_KEY_VALUE = "[KEY]";
+    private static final int IDLE_TIMEOUT = 123;
+
+    private ConnectionFactoryConfig connectionFactoryConfig;
+
+    @Override
+    protected void setUpLocalTests() {
+        connectionFactoryConfig = new ConnectionFactoryConfig();
+    }
+
+    @Test
+    void testConnectionFactoryConfig() {
+        String serviceBusConnecitonString =
+            String.format("Endpoint=sb://%s;SharedAccessKeyName=%s;SharedAccessKey=%s",
+                          SERVICE_BUS_HOST,
+                          SERVICE_BUS_ACCESS_KEY_NAME,
+                          SERVICE_BUS_ACCESS_KEY_VALUE
+            );
+
+        connectionFactoryConfig.setConnectionString(serviceBusConnecitonString);
+        connectionFactoryConfig.setIdleTimeout(IDLE_TIMEOUT);
+
+        CachingConnectionFactory connectionFactory =
+            (CachingConnectionFactory) connectionFactoryConfig.connectionFactory();
+
+        JmsConnectionFactory jmsConnectionFactory =
+            (JmsConnectionFactory) connectionFactory.getTargetConnectionFactory();
+
+        String serviceBusRemoteUri =
+            String.format("failover:(amqps://%s?amqp.idleTimeout=%s)", SERVICE_BUS_HOST, IDLE_TIMEOUT);
+        assertEquals(serviceBusRemoteUri,
+                     jmsConnectionFactory.getRemoteURI(),
+                     "JmsConnectionFactory has unexpected remote URI");
+
+        assertEquals(SERVICE_BUS_ACCESS_KEY_NAME,
+                     jmsConnectionFactory.getUsername(),
+                     "JmsConnectionFactory has unexpected access key name");
+        assertEquals(SERVICE_BUS_ACCESS_KEY_VALUE,
+                     jmsConnectionFactory.getPassword(),
+                     "JmsConnectionFactory has unexpected access key value");
+
+        JmsDefaultPrefetchPolicy jmsDefaultPrefetchPolicy =
+            (JmsDefaultPrefetchPolicy) jmsConnectionFactory.getPrefetchPolicy();
+
+        assertPreFetchValue(jmsDefaultPrefetchPolicy.getQueuePrefetch(), "queue");
+        assertPreFetchValue(jmsDefaultPrefetchPolicy.getTopicPrefetch(), "topic");
+        assertPreFetchValue(jmsDefaultPrefetchPolicy.getDurableTopicPrefetch(), "durable topic");
+        assertPreFetchValue(jmsDefaultPrefetchPolicy.getQueueBrowserPrefetch(), "queue browser");
+    }
+
+    private void assertPreFetchValue(int prefetchValue, String prefetchName) {
+        assertEquals(0, prefetchValue, "JmsConnectionFactory has unexpected " + prefetchName + " prefetch value");
+    }
+}

--- a/services/src/unit-test/java/uk/gov/moj/sdt/services/mbeans/SdtManagementMBeanTest.java
+++ b/services/src/unit-test/java/uk/gov/moj/sdt/services/mbeans/SdtManagementMBeanTest.java
@@ -1,30 +1,29 @@
 package uk.gov.moj.sdt.services.mbeans;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.stubbing.Answer;
 import org.springframework.jms.listener.DefaultMessageListenerContainer;
-import org.springframework.util.ReflectionUtils;
 import uk.gov.moj.sdt.dao.api.IIndividualRequestDao;
 import uk.gov.moj.sdt.domain.IndividualRequest;
 import uk.gov.moj.sdt.domain.api.IIndividualRequest;
 import uk.gov.moj.sdt.services.api.ITargetApplicationSubmissionService;
-import uk.gov.moj.sdt.services.utils.api.IMessagingUtility;
+import uk.gov.moj.sdt.services.utils.RequeueIndividualRequestUtility;
 import uk.gov.moj.sdt.utils.AbstractSdtUnitTestBase;
 import uk.gov.moj.sdt.utils.mbeans.api.ISdtManagementMBean;
 
-import java.lang.reflect.Field;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -41,12 +40,6 @@ class SdtManagementMBeanTest extends AbstractSdtUnitTestBase {
      */
     @Mock
     private IIndividualRequestDao mockIndividualRequestDao;
-
-    /**
-     * This mock messaging utility reference for testing.
-     */
-    @Mock
-    private IMessagingUtility mockMessagingUtility;
 
     /**
      * This mock variable holding the target application submission service.
@@ -118,30 +111,17 @@ class SdtManagementMBeanTest extends AbstractSdtUnitTestBase {
     private DefaultMessageListenerContainer messageListenerContainer;
 
     @Mock
-    private IMessagingUtility messagingUtility;
-
-    @Mock
-    private ITargetApplicationSubmissionService targetAppSubmissionService;
+    private RequeueIndividualRequestUtility mockRequeueIndividualRequestUtility;
 
     /**
      * Method to do any pre-test set-up.
      */
-    @BeforeEach
     @Override
-    public void setUp() {
+    protected void setUpLocalTests() {
         sdtManagementMBean = new SdtManagementMBean(messageListenerContainer,
                                                     mockIndividualRequestDao,
-                                                    messagingUtility,
-                                                    targetAppSubmissionService);
-        // Instantiate all the mocked objects and set them up in the MBean
-        this.setPrivateField(SdtManagementMBean.class, sdtManagementMBean, "individualRequestDao",
-                IIndividualRequestDao.class, mockIndividualRequestDao);
-
-        this.setPrivateField(SdtManagementMBean.class, sdtManagementMBean, "messagingUtility",
-                IMessagingUtility.class, mockMessagingUtility);
-
-        this.setPrivateField(SdtManagementMBean.class, sdtManagementMBean, "targetAppSubmissionService",
-                ITargetApplicationSubmissionService.class, mockTargetAppSubmissionService);
+                                                    mockRequeueIndividualRequestUtility,
+                                                    mockTargetAppSubmissionService);
     }
 
     /**
@@ -223,6 +203,7 @@ class SdtManagementMBeanTest extends AbstractSdtUnitTestBase {
         this.sdtManagementMBean.requeueOldIndividualRequests(TEST_STALE_DURATION);
 
         verify(mockIndividualRequestDao).getStaleIndividualRequests(TEST_STALE_DURATION);
+        verify(mockRequeueIndividualRequestUtility, never()).requeueIndividualRequest(any(IIndividualRequest.class));
 
         assertTrue(true, "Not expected to call the method to requeue requests");
     }
@@ -239,19 +220,12 @@ class SdtManagementMBeanTest extends AbstractSdtUnitTestBase {
         final List<IIndividualRequest> individualRequests = new ArrayList<>();
         individualRequests.add(individualRequest);
 
-        when(mockIndividualRequestDao.getStaleIndividualRequests(TEST_STALE_DURATION)).thenReturn(
-                individualRequests);
-
-        mockMessagingUtility.enqueueRequest(individualRequest);
-
-        individualRequest.resetForwardingAttempts();
-
-        mockIndividualRequestDao.persistBulk(individualRequests);
+        when(mockIndividualRequestDao.getStaleIndividualRequests(TEST_STALE_DURATION)).thenReturn(individualRequests);
 
         this.sdtManagementMBean.requeueOldIndividualRequests(TEST_STALE_DURATION);
 
         verify(mockIndividualRequestDao).getStaleIndividualRequests(TEST_STALE_DURATION);
-        verify(mockMessagingUtility, atLeastOnce()).enqueueRequest(individualRequest);
+        verify(mockRequeueIndividualRequestUtility).requeueIndividualRequest(individualRequest);
 
         assertTrue(true, "All tests passed");
     }
@@ -407,24 +381,4 @@ class SdtManagementMBeanTest extends AbstractSdtUnitTestBase {
 
         assertEquals(OK_MESSAGE, returnVal, "The return value is OK");
     }
-
-    /**
-     * This is a method to modify a private field with no accessor methods.
-     *
-     * @param concreteClazz        this is the class with the field accessor being changed (e.g.
-     *                             MyClazz.class)
-     * @param classInstance        this is the instance with the field state being changed (e.g.
-     *                             myClazz)
-     * @param instanceVariableName this is the field name (e.g. "myString")
-     * @param variableClazz        this is the class of the field's type (e.g. String.class)
-     * @param newFieldState        the new value of the filed (e.g. "a new value")
-     */
-    public void setPrivateField(final Class<?> concreteClazz, final Object classInstance,
-                                final String instanceVariableName, final Class<?> variableClazz,
-                                final Object newFieldState) {
-        final Field field = ReflectionUtils.findField(concreteClazz, instanceVariableName, variableClazz);
-        ReflectionUtils.makeAccessible(field);
-        ReflectionUtils.setField(field, classInstance, newFieldState);
-    }
-
 }

--- a/services/src/unit-test/java/uk/gov/moj/sdt/services/messaging/JmsTemplateConfigTest.java
+++ b/services/src/unit-test/java/uk/gov/moj/sdt/services/messaging/JmsTemplateConfigTest.java
@@ -1,0 +1,38 @@
+package uk.gov.moj.sdt.services.messaging;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jms.core.JmsTemplate;
+import uk.gov.moj.sdt.utils.AbstractSdtUnitTestBase;
+
+import javax.jms.ConnectionFactory;
+
+import static javax.jms.Session.CLIENT_ACKNOWLEDGE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(MockitoExtension.class)
+class JmsTemplateConfigTest extends AbstractSdtUnitTestBase {
+
+    @Mock
+    ConnectionFactory mockConnectionFactory;
+
+    private JmsTemplateConfig jmsTemplateConfig;
+
+    @Override
+    protected void setUpLocalTests() {
+        jmsTemplateConfig = new JmsTemplateConfig();
+    }
+
+    @Test
+    void testJmsTemplateConfig() {
+        JmsTemplate jmsTemplate = jmsTemplateConfig.jmsTemplate(mockConnectionFactory);
+
+        assertTrue(jmsTemplate.isSessionTransacted(), "JmsTemplate session transacted should be true");
+        assertEquals(CLIENT_ACKNOWLEDGE,
+                     jmsTemplate.getSessionAcknowledgeMode(),
+                     "JmsTemplate has unexpected session acknowledge mode");
+    }
+}

--- a/services/src/unit-test/java/uk/gov/moj/sdt/services/utils/RequeueIndividualRequestUtilityTest.java
+++ b/services/src/unit-test/java/uk/gov/moj/sdt/services/utils/RequeueIndividualRequestUtilityTest.java
@@ -1,0 +1,55 @@
+package uk.gov.moj.sdt.services.utils;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.moj.sdt.dao.api.IIndividualRequestDao;
+import uk.gov.moj.sdt.domain.IndividualRequest;
+import uk.gov.moj.sdt.services.utils.api.IMessagingUtility;
+import uk.gov.moj.sdt.utils.AbstractSdtUnitTestBase;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.verify;
+import static uk.gov.moj.sdt.domain.api.IIndividualRequest.IndividualRequestStatus.FORWARDED;
+import static uk.gov.moj.sdt.domain.api.IIndividualRequest.IndividualRequestStatus.RECEIVED;
+
+@ExtendWith(MockitoExtension.class)
+class RequeueIndividualRequestUtilityTest extends AbstractSdtUnitTestBase {
+
+    @Mock
+    IIndividualRequestDao mockIndividualRequestDao;
+
+    @Mock
+    private IMessagingUtility mockMessagingUtility;
+
+    private RequeueIndividualRequestUtility requeueIndividualRequestUtility;
+
+    @Override
+    protected void setUpLocalTests() {
+        requeueIndividualRequestUtility =
+            new RequeueIndividualRequestUtility(mockIndividualRequestDao, mockMessagingUtility);
+    }
+
+    @Test
+    void testRequeueIndividualRequest() {
+        IndividualRequest individualRequest = new IndividualRequest();
+        individualRequest.setRequestStatus(FORWARDED.getStatus());
+        individualRequest.setForwardingAttempts(2);
+        individualRequest.setDeadLetter(true);
+
+        requeueIndividualRequestUtility.requeueIndividualRequest(individualRequest);
+
+        assertEquals(RECEIVED.getStatus(),
+                     individualRequest.getRequestStatus(),
+                     "Individual request has unexpected request status");
+        assertEquals(0,
+                     individualRequest.getForwardingAttempts(),
+                     "Individual request has unexpected number of forwarding attempts");
+        assertFalse(individualRequest.isDeadLetter(), "Individual request dead letter flag should not be true");
+
+        verify(mockMessagingUtility).enqueueRequest(individualRequest);
+        verify(mockIndividualRequestDao).persist(individualRequest);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -14,10 +14,6 @@ management:
 springdoc:
   packagesToScan: uk.gov.moj.sdt.controllers
 
-enable-jms: ${ENABLE_JMS:false}
-enable-queue-reset: ${ENABLE_QUEUE_RESET:false}
-enable-single-executor: ${ENABLE_SINGLE_EXECUTOR:false}
-
 spring:
   jms:
     servicebus:


### PR DESCRIPTION
### JIRA link (if applicable) ###
SDT-231 (https://tools.hmcts.net/jira/browse/SDT-231)


### Change description ###
- Removed feature flags from application.yaml
- Added service bus properties to integration test application YAML files.
- Added connection factory configuration class for creating a connection factory for the service bus.
- Added a test connection factory configuration class for creating a connection factory for ActiveMQ which is used by the integration tests.
- Updated integration tests to include test connection factory configuration class.
- Removed feature flag from JmsTemplateConfig class.
- Removed feature flag and associated queue reset code from MessageWriter class.
- Removed feature flag and associated single executor code from MessagingUtility class.
- Added RequeueIndividualRequestUtility class.
- Amended SdtManagementMBean class to use RequeueIndividualRequestUtility class instead of MessagingUtility class.  Also removed redundant code and refactored logging statements.
- Updated SdtManagementMBeanTest class to reflect changes to SdtManagementMBean.  Removed redundant code.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
