### PR TITLE
SDT-200: Handle Case Locked notifications from CMC

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -166,7 +166,7 @@ ext {
   cxfVersion = '3.6.4'
   jaxwsVersion = "2.3.1"
   testcontainers = '1.20.2'
-  sdtCommonVersion = '3.2.1-SDT-200.0.3'
+  sdtCommonVersion = '3.2.1-phase-3.0.3'
   limits = [
     'instruction': 99,
     'branch'     : 99,

--- a/build.gradle
+++ b/build.gradle
@@ -166,7 +166,7 @@ ext {
   cxfVersion = '3.6.4'
   jaxwsVersion = "2.3.1"
   testcontainers = '1.20.2'
-  sdtCommonVersion = '3.2.1-phase-3.0.2'
+  sdtCommonVersion = '3.2.1-SDT-200.0.3'
   limits = [
     'instruction': 99,
     'branch'     : 99,

--- a/consumers/src/main/java/uk/gov/moj/sdt/cmc/consumers/CMCConsumerGateway.java
+++ b/consumers/src/main/java/uk/gov/moj/sdt/cmc/consumers/CMCConsumerGateway.java
@@ -18,6 +18,7 @@ import uk.gov.moj.sdt.cmc.consumers.api.IJudgementService;
 import uk.gov.moj.sdt.cmc.consumers.api.IJudgementWarrantService;
 import uk.gov.moj.sdt.cmc.consumers.api.IWarrantService;
 import uk.gov.moj.sdt.cmc.consumers.converter.XmlConverter;
+import uk.gov.moj.sdt.cmc.consumers.exception.CMCCaseLockedException;
 import uk.gov.moj.sdt.cmc.consumers.model.claimdefences.ClaimDefencesResponse;
 import uk.gov.moj.sdt.cmc.consumers.request.BreathingSpaceRequest;
 import uk.gov.moj.sdt.cmc.consumers.request.ClaimStatusUpdateRequest;
@@ -147,6 +148,9 @@ public class CMCConsumerGateway implements IConsumerGateway {
             } else {
                 throw e;
             }
+        } catch (CMCCaseLockedException e) {
+            LOGGER.info("Case locked for SDT reference [{}]", individualRequest.getSdtRequestReference());
+            individualRequest.markRequestAsCaseLocked();
         } catch (Exception e) {
             String message = e.getMessage();
             if (message != null && message.contains(CASE_OFF_LINE)) {

--- a/consumers/src/main/java/uk/gov/moj/sdt/cmc/consumers/config/CMCConfig.java
+++ b/consumers/src/main/java/uk/gov/moj/sdt/cmc/consumers/config/CMCConfig.java
@@ -1,10 +1,18 @@
 package uk.gov.moj.sdt.cmc.consumers.config;
 
+import feign.codec.ErrorDecoder;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import uk.gov.moj.sdt.cmc.consumers.api.CMCApi;
+import uk.gov.moj.sdt.cmc.consumers.decoder.CMCErrorDecoder;
 
 @Configuration
 @EnableFeignClients(clients = {CMCApi.class})
 public class CMCConfig {
+
+    @Bean
+    public ErrorDecoder errorDecoder() {
+        return new CMCErrorDecoder();
+    }
 }

--- a/consumers/src/main/java/uk/gov/moj/sdt/cmc/consumers/decoder/CMCErrorDecoder.java
+++ b/consumers/src/main/java/uk/gov/moj/sdt/cmc/consumers/decoder/CMCErrorDecoder.java
@@ -1,0 +1,54 @@
+package uk.gov.moj.sdt.cmc.consumers.decoder;
+
+import feign.Response;
+import feign.Util;
+import feign.codec.ErrorDecoder;
+import lombok.extern.slf4j.Slf4j;
+import uk.gov.moj.sdt.cmc.consumers.exception.CMCCaseLockedException;
+import uk.gov.moj.sdt.utils.cmc.exception.CMCException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+@Slf4j
+public class CMCErrorDecoder implements ErrorDecoder {
+
+    @Override
+    public Exception decode(String methodKey, Response response) {
+        if (response.status() == 423) {
+            return new CMCCaseLockedException();
+        } else {
+            return createCMCException(response);
+        }
+    }
+
+    private CMCException createCMCException(Response response) {
+        String responseBody = responseBodyToString(response.body());
+
+        String messageStatusElement = "status: " + response.status();
+        String messageBodyElement = responseBody.isEmpty() ? "" : ", body: " + responseBody;
+        return new CMCException(messageStatusElement + messageBodyElement);
+    }
+
+    /**
+     * Convert the body of the response to a string.  Only used for unexpected errors.
+     *
+     * @param responseBody The body of the response
+     * @return A string containing the body with line breaks removed
+     */
+    private String responseBodyToString(Response.Body responseBody) {
+        String body = "";
+
+        if (responseBody != null) {
+            try (InputStream inputStream = responseBody.asInputStream()) {
+                byte[] bodyBytes = Util.toByteArray(inputStream);
+                body = new String(bodyBytes, StandardCharsets.UTF_8).replaceAll("[\\r\\n]", "").trim();
+            } catch (IOException e) {
+                log.error("Unable to read response body");
+            }
+        }
+
+        return body;
+    }
+}

--- a/consumers/src/main/java/uk/gov/moj/sdt/cmc/consumers/exception/CMCCaseLockedException.java
+++ b/consumers/src/main/java/uk/gov/moj/sdt/cmc/consumers/exception/CMCCaseLockedException.java
@@ -1,0 +1,13 @@
+package uk.gov.moj.sdt.cmc.consumers.exception;
+
+import java.io.Serial;
+
+public class CMCCaseLockedException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 4125036333653935089L;
+
+    public CMCCaseLockedException() {
+        super();
+    }
+}

--- a/consumers/src/unit-test/java/uk/gov/moj/sdt/cmc/consumers/decoder/CMCErrorDecoderTest.java
+++ b/consumers/src/unit-test/java/uk/gov/moj/sdt/cmc/consumers/decoder/CMCErrorDecoderTest.java
@@ -1,0 +1,91 @@
+package uk.gov.moj.sdt.cmc.consumers.decoder;
+
+import feign.Request;
+import feign.Response;
+import org.junit.jupiter.api.Test;
+import uk.gov.moj.sdt.cmc.consumers.exception.CMCCaseLockedException;
+import uk.gov.moj.sdt.utils.AbstractSdtUnitTestBase;
+import uk.gov.moj.sdt.utils.cmc.exception.CMCException;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+class CMCErrorDecoderTest extends AbstractSdtUnitTestBase {
+
+    private static final String METHOD_KEY = "testMethodKey";
+    private static final String REQUEST_URL = "testUrl";
+
+    private static final int STATUS_NOT_FOUND = 404;
+    private static final int STATUS_CASE_LOCKED = 423;
+    private static final int STATUS_INTERNAL_SERVER_ERROR = 500;
+
+    private static final String ERROR_UNEXPECTED_EXCEPTION = "Error decoder returned an unexpected exception";
+
+    private CMCErrorDecoder cmcErrorDecoder;
+
+    @Override
+    protected void setUpLocalTests() {
+        cmcErrorDecoder = new CMCErrorDecoder();
+    }
+
+    @Test
+    void testDecodeCaseLockedException() {
+        Response response = createResponse(STATUS_CASE_LOCKED);
+
+        Exception exception = cmcErrorDecoder.decode(METHOD_KEY, response);
+
+        assertInstanceOf(CMCCaseLockedException.class, exception, ERROR_UNEXPECTED_EXCEPTION);
+    }
+
+    @Test
+    void testDecodeUnexpectedException() {
+        String responseBody = "{\"status\" : 404, \"error\" : \"Not Found\"}";
+        Response response = createResponseWithBody(STATUS_NOT_FOUND, responseBody);
+
+        Exception exception = cmcErrorDecoder.decode(METHOD_KEY, response);
+
+        assertInstanceOf(CMCException.class, exception, ERROR_UNEXPECTED_EXCEPTION);
+
+        String expectedResponseBody = "status: 404, body: " + responseBody;
+        assertEquals(expectedResponseBody, exception.getMessage(), "CMCException has unexpected message");
+    }
+
+    @Test
+    void testDecodeUnexpectedExceptionNoBody() {
+        Response response = createResponse(STATUS_INTERNAL_SERVER_ERROR);
+
+        Exception exception = cmcErrorDecoder.decode(METHOD_KEY, response);
+
+        assertInstanceOf(CMCException.class, exception, ERROR_UNEXPECTED_EXCEPTION);
+        assertEquals("status: 500", exception.getMessage(), "CMCException has unexpected message");
+    }
+
+    private Response createResponse(int status) {
+        return createResponseBuilder(status).build();
+    }
+
+    private Response createResponseWithBody(int status, String responseBody) {
+        return createResponseBuilder(status).body(responseBody.getBytes(StandardCharsets.UTF_8)).build();
+    }
+
+    private Response.Builder createResponseBuilder(int status) {
+        Response.Builder builder = Response.builder();
+        builder.status(status).request(createRequest());
+
+        return builder;
+    }
+
+    /**
+     * Create a dummy feign Request.  This is needed to be able to create a feign Response.
+     * @return A dummy feign Request
+     */
+    private Request createRequest() {
+        Map<String, Collection<String>> headers = new HashMap<>();
+        return Request.create(Request.HttpMethod.POST, REQUEST_URL, headers, null, null, null);
+    }
+}

--- a/dao/src/integ-test/resources/application-integ.yaml
+++ b/dao/src/integ-test/resources/application-integ.yaml
@@ -51,6 +51,9 @@ sdt:
   requeue:
     cron: ${REQUEUE_SCHEDULE_CRON:0 */20 * * * ?}
     minimumAge: ${MINIMUM_AGE:15}
+  case-locked:
+    cron: ${CASELOCKED_SCHEDULE_CRON:0 */5 * * * ?}
+    minimumAge: ${CASELOCKED_MINIMUM_AGE:60}
 idam:
   s2s-auth:
     microservice: civil_sdt

--- a/services/src/integ-test/resources/application-integ.yaml
+++ b/services/src/integ-test/resources/application-integ.yaml
@@ -55,6 +55,9 @@ sdt:
   requeue:
     cron: ${REQUEUE_SCHEDULE_CRON:0 */20 * * * ?}
     minimumAge: ${MINIMUM_AGE:15}
+  case-locked:
+    cron: ${CASELOCKED_SCHEDULE_CRON:0 */5 * * * ?}
+    minimumAge: ${CASELOCKED_MINIMUM_AGE:60}
 idam:
   s2s-auth:
     microservice: civil_sdt

--- a/services/src/main/java/uk/gov/moj/sdt/services/RetryCaseLockedService.java
+++ b/services/src/main/java/uk/gov/moj/sdt/services/RetryCaseLockedService.java
@@ -1,0 +1,58 @@
+package uk.gov.moj.sdt.services;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import uk.gov.moj.sdt.dao.api.IIndividualRequestDao;
+import uk.gov.moj.sdt.domain.api.IIndividualRequest;
+import uk.gov.moj.sdt.services.utils.RetryCaseLockedUtility;
+import uk.gov.moj.sdt.services.utils.api.IMessagingUtility;
+
+import java.util.List;
+
+@Slf4j
+@Setter
+@Service
+public class RetryCaseLockedService {
+
+    private IIndividualRequestDao individualRequestDao;
+
+    private RetryCaseLockedUtility retryCaseLockedUtility;
+
+    @Value("${sdt.case-locked.minimumAge:60}")
+    @Getter
+    private int minimumAge;
+
+    @Autowired
+    public RetryCaseLockedService(@Qualifier("IndividualRequestDao") IIndividualRequestDao individualRequestDao,
+                                  @Qualifier("retryCaseLockedUtility") RetryCaseLockedUtility retryCaseLockedUtility) {
+        this.individualRequestDao = individualRequestDao;
+        this.retryCaseLockedUtility = retryCaseLockedUtility;
+    }
+
+    @Scheduled(cron = "${sdt.case-locked.cron}")
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void retryCaseLockedIndividualRequests() {
+        log.debug("Start scheduled job to retry case locked requests");
+
+        final List<IIndividualRequest> requests = individualRequestDao.getCaseLockedIndividualRequests(minimumAge);
+
+        if (requests.isEmpty()) {
+            log.info("No case locked requests to retry");
+        } else {
+            log.info("Retrying {} case locked request(s) older than {} minutes", requests.size(), minimumAge);
+
+            for (IIndividualRequest individualRequest : requests) {
+                retryCaseLockedUtility.retryCaseLockedIndividualRequest(individualRequest);
+            }
+        }
+        log.debug("End scheduled job to retry case locked requests");
+    }
+}

--- a/services/src/main/java/uk/gov/moj/sdt/services/utils/RetryCaseLockedUtility.java
+++ b/services/src/main/java/uk/gov/moj/sdt/services/utils/RetryCaseLockedUtility.java
@@ -1,0 +1,37 @@
+package uk.gov.moj.sdt.services.utils;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import uk.gov.moj.sdt.dao.api.IIndividualRequestDao;
+import uk.gov.moj.sdt.domain.api.IIndividualRequest;
+import uk.gov.moj.sdt.services.utils.api.IMessagingUtility;
+
+@Component("retryCaseLockedUtility")
+@Slf4j
+public class RetryCaseLockedUtility {
+
+    private IIndividualRequestDao individualRequestDao;
+
+    private IMessagingUtility messagingUtility;
+
+    @Autowired
+    public RetryCaseLockedUtility(@Qualifier("IndividualRequestDao") IIndividualRequestDao individualRequestDao,
+                                  @Qualifier("MessagingUtility") IMessagingUtility messagingUtility) {
+        this.individualRequestDao = individualRequestDao;
+        this.messagingUtility = messagingUtility;
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void retryCaseLockedIndividualRequest(IIndividualRequest individualRequest) {
+        log.debug("Retrying case locked individual request [{}]", individualRequest.getSdtRequestReference());
+
+        individualRequest.resetForwardingAttempts();
+        individualRequestDao.persist(individualRequest);
+
+        messagingUtility.enqueueRequest(individualRequest);
+    }
+}

--- a/services/src/main/java/uk/gov/moj/sdt/services/utils/RetryCaseLockedUtility.java
+++ b/services/src/main/java/uk/gov/moj/sdt/services/utils/RetryCaseLockedUtility.java
@@ -14,9 +14,9 @@ import uk.gov.moj.sdt.services.utils.api.IMessagingUtility;
 @Slf4j
 public class RetryCaseLockedUtility {
 
-    private IIndividualRequestDao individualRequestDao;
+    private final IIndividualRequestDao individualRequestDao;
 
-    private IMessagingUtility messagingUtility;
+    private final IMessagingUtility messagingUtility;
 
     @Autowired
     public RetryCaseLockedUtility(@Qualifier("IndividualRequestDao") IIndividualRequestDao individualRequestDao,

--- a/services/src/unit-test/java/uk/gov/moj/sdt/services/RetryCaseLockedServiceTest.java
+++ b/services/src/unit-test/java/uk/gov/moj/sdt/services/RetryCaseLockedServiceTest.java
@@ -1,0 +1,75 @@
+package uk.gov.moj.sdt.services;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.moj.sdt.dao.api.IIndividualRequestDao;
+import uk.gov.moj.sdt.domain.IndividualRequest;
+import uk.gov.moj.sdt.domain.api.IIndividualRequest;
+import uk.gov.moj.sdt.services.utils.RetryCaseLockedUtility;
+import uk.gov.moj.sdt.utils.AbstractSdtUnitTestBase;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RetryCaseLockedServiceTest extends AbstractSdtUnitTestBase {
+
+    private static final int MINIMUM_AGE_IN_MINUTES = 60;
+
+    @Mock
+    private IIndividualRequestDao mockIndividualRequestDao;
+
+    @Mock
+    private RetryCaseLockedUtility mockRetryCaseLockedUtility;
+
+    private RetryCaseLockedService retryCaseLockedService;
+
+    @Override
+    protected void setUpLocalTests() {
+        retryCaseLockedService = new RetryCaseLockedService(mockIndividualRequestDao, mockRetryCaseLockedUtility);
+        retryCaseLockedService.setMinimumAge(MINIMUM_AGE_IN_MINUTES);
+    }
+
+    @Test
+    void testCaseLockedRequests() {
+        List<IIndividualRequest> individualRequests = new ArrayList<>();
+        individualRequests.add(createIndividualRequest("MCOL-20241016000000-000000001-0000001"));
+        individualRequests.add(createIndividualRequest("MCOL-20241016000000-000000001-0000002"));
+
+        when(mockIndividualRequestDao.getCaseLockedIndividualRequests(MINIMUM_AGE_IN_MINUTES))
+            .thenReturn(individualRequests);
+
+        retryCaseLockedService.retryCaseLockedIndividualRequests();
+
+        verify(mockIndividualRequestDao).getCaseLockedIndividualRequests(MINIMUM_AGE_IN_MINUTES);
+        verify(mockRetryCaseLockedUtility, times(2)).retryCaseLockedIndividualRequest(any(IIndividualRequest.class));
+    }
+
+    @Test
+    void testNoCaseLockedRequests() {
+        List<IIndividualRequest> individualRequests = new ArrayList<>();
+        when(mockIndividualRequestDao.getCaseLockedIndividualRequests(MINIMUM_AGE_IN_MINUTES))
+            .thenReturn(individualRequests);
+
+        retryCaseLockedService.retryCaseLockedIndividualRequests();
+
+        verify(mockIndividualRequestDao).getCaseLockedIndividualRequests(MINIMUM_AGE_IN_MINUTES);
+        verify(mockRetryCaseLockedUtility, never()).retryCaseLockedIndividualRequest(any(IIndividualRequest.class));
+    }
+
+    private IIndividualRequest createIndividualRequest(String requestRef) {
+        IIndividualRequest individualRequest = new IndividualRequest();
+        individualRequest.setSdtRequestReference(requestRef);
+        individualRequest.markRequestAsCaseLocked();
+
+        return individualRequest;
+    }
+}

--- a/services/src/unit-test/java/uk/gov/moj/sdt/services/utils/RetryCaseLockedUtilityTest.java
+++ b/services/src/unit-test/java/uk/gov/moj/sdt/services/utils/RetryCaseLockedUtilityTest.java
@@ -1,0 +1,53 @@
+package uk.gov.moj.sdt.services.utils;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.moj.sdt.dao.api.IIndividualRequestDao;
+import uk.gov.moj.sdt.domain.IndividualRequest;
+import uk.gov.moj.sdt.domain.api.IIndividualRequest;
+import uk.gov.moj.sdt.services.utils.api.IMessagingUtility;
+import uk.gov.moj.sdt.utils.AbstractSdtUnitTestBase;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class RetryCaseLockedUtilityTest extends AbstractSdtUnitTestBase {
+
+    @Mock
+    private IIndividualRequestDao mockIndividualRequestDao;
+
+    @Mock
+    private IMessagingUtility mockMessagingUtility;
+
+    private RetryCaseLockedUtility retryCaseLockedUtility;
+
+    @Override
+    protected void setUpLocalTests() {
+        retryCaseLockedUtility = new RetryCaseLockedUtility(mockIndividualRequestDao, mockMessagingUtility);
+    }
+
+    @Test
+    void testRetryCaseLockedIndividualRequest() {
+        IIndividualRequest individualRequest = new IndividualRequest();
+        individualRequest.setRequestStatus(IIndividualRequest.IndividualRequestStatus.CASE_LOCKED.getStatus());
+        individualRequest.setForwardingAttempts(1);
+
+        retryCaseLockedUtility.retryCaseLockedIndividualRequest(individualRequest);
+
+        assertEquals(IIndividualRequest.IndividualRequestStatus.RECEIVED.getStatus(),
+                     individualRequest.getRequestStatus(),
+                     "Individual request has unexpected request status");
+        assertEquals(0,
+                     individualRequest.getForwardingAttempts(),
+                     "Individual request has unexpected forwarding attempts value");
+        assertNotNull(individualRequest.getUpdatedDate(), "Individual request updated date should not be null");
+
+        verify(mockIndividualRequestDao).persist(individualRequest);
+        verify(mockMessagingUtility).enqueueRequest(individualRequest);
+
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -82,6 +82,9 @@ sdt:
   requeue:
     cron: ${REQUEUE_SCHEDULE_CRON:0 */20 * * * ?}
     minimumAge: ${MINIMUM_AGE:15}
+  case-locked:
+    cron: ${CASELOCKED_SCHEDULE_CRON:0 */5 * * * ?}
+    minimumAge: ${CASELOCKED_MINIMUM_AGE:60}
 feign:
   circuitbreaker:
     enabled: true


### PR DESCRIPTION
### JIRA link (if applicable) ###
SDT-200 (https://tools.hmcts.net/jira/browse/SDT-200)


### Change description ###
Added CMCCaseLockedException class.

Added CMCErrorDecoder class to translate error responses from CMC to specific exception types.

Updated CMCConfig to create CMCErrorDecoder bean.

Updated CMCConsumerGateway to handle CMCCaseLockedExceptions.

Added RetryCaseLockedService and RetryCaseLockedUtility classes.  These implement the process to retry individual requests that have received a case locked notification after a configurable period of time has elapsed.

Added method to IndividualRequestDao to get individual requests that have been in case locked state for more than a specified period of time.

Updated application.yaml with parameters for RetryCaseLockedService.

Added unit test classes for new classes.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
