### PR TITLE
SDT-203: Handle CMC errors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -166,7 +166,7 @@ ext {
   cxfVersion = '3.6.4'
   jaxwsVersion = "2.3.1"
   testcontainers = '1.20.2'
-  sdtCommonVersion = '3.2.1-SDT-203.0.1'
+  sdtCommonVersion = '3.2.1-phase-3.0.4'
   limits = [
     'instruction': 99,
     'branch'     : 99,

--- a/build.gradle
+++ b/build.gradle
@@ -166,7 +166,7 @@ ext {
   cxfVersion = '3.6.4'
   jaxwsVersion = "2.3.1"
   testcontainers = '1.20.2'
-  sdtCommonVersion = '3.2.1-phase-3.0.4'
+  sdtCommonVersion = '3.2.1-phase-3.0.5'
   limits = [
     'instruction': 99,
     'branch'     : 99,

--- a/build.gradle
+++ b/build.gradle
@@ -166,7 +166,7 @@ ext {
   cxfVersion = '3.6.4'
   jaxwsVersion = "2.3.1"
   testcontainers = '1.20.2'
-  sdtCommonVersion = '3.2.1-phase-3.0.3'
+  sdtCommonVersion = '3.2.1-SDT-203.0.1'
   limits = [
     'instruction': 99,
     'branch'     : 99,

--- a/consumers/src/main/java/uk/gov/moj/sdt/cmc/consumers/decoder/CMCErrorDecoder.java
+++ b/consumers/src/main/java/uk/gov/moj/sdt/cmc/consumers/decoder/CMCErrorDecoder.java
@@ -28,8 +28,9 @@ public class CMCErrorDecoder implements ErrorDecoder {
         String responseBody = responseBodyToString(response.body());
 
         if (responseStatus == STATUS_BAD_REQUEST) {
-            CMCRejectedException cmcRejectedException = cmcRejectedException(responseBody);
-            return Objects.requireNonNullElseGet(cmcRejectedException, () -> createCMCException(responseStatus, responseBody));
+            CMCRejectedException cmcRejectedException = createCMCRejectedException(responseBody);
+            return Objects.requireNonNullElseGet(cmcRejectedException,
+                                                 () -> createCMCException(responseStatus, responseBody));
         } else if (responseStatus == STATUS_LOCKED) {
             return new CMCCaseLockedException();
         } else {
@@ -58,7 +59,7 @@ public class CMCErrorDecoder implements ErrorDecoder {
         return body;
     }
 
-    private CMCRejectedException cmcRejectedException(String responseBody) {
+    private CMCRejectedException createCMCRejectedException(String responseBody) {
         CMCRejectedException cmcRejectedException = null;
 
         if (responseBody != null) {

--- a/consumers/src/main/java/uk/gov/moj/sdt/cmc/consumers/decoder/CMCErrorDecoder.java
+++ b/consumers/src/main/java/uk/gov/moj/sdt/cmc/consumers/decoder/CMCErrorDecoder.java
@@ -1,38 +1,44 @@
 package uk.gov.moj.sdt.cmc.consumers.decoder;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import feign.Response;
 import feign.Util;
 import feign.codec.ErrorDecoder;
 import lombok.extern.slf4j.Slf4j;
 import uk.gov.moj.sdt.cmc.consumers.exception.CMCCaseLockedException;
+import uk.gov.moj.sdt.cmc.consumers.exception.CMCRejectedException;
+import uk.gov.moj.sdt.cmc.consumers.response.ErrorResponse;
 import uk.gov.moj.sdt.utils.cmc.exception.CMCException;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 
 @Slf4j
 public class CMCErrorDecoder implements ErrorDecoder {
 
+    private static final int STATUS_BAD_REQUEST = 400;
+    private static final int STATUS_LOCKED = 423;
+
     @Override
     public Exception decode(String methodKey, Response response) {
-        if (response.status() == 423) {
+        int responseStatus = response.status();
+        String responseBody = responseBodyToString(response.body());
+
+        if (responseStatus == STATUS_BAD_REQUEST) {
+            CMCRejectedException cmcRejectedException = cmcRejectedException(responseBody);
+            return Objects.requireNonNullElseGet(cmcRejectedException, () -> createCMCException(responseStatus, responseBody));
+        } else if (responseStatus == STATUS_LOCKED) {
             return new CMCCaseLockedException();
         } else {
-            return createCMCException(response);
+            return createCMCException(responseStatus, responseBody);
         }
     }
 
-    private CMCException createCMCException(Response response) {
-        String responseBody = responseBodyToString(response.body());
-
-        String messageStatusElement = "status: " + response.status();
-        String messageBodyElement = responseBody.isEmpty() ? "" : ", body: " + responseBody;
-        return new CMCException(messageStatusElement + messageBodyElement);
-    }
-
     /**
-     * Convert the body of the response to a string.  Only used for unexpected errors.
+     * Convert the body of the response to a string with any line breaks removed.
      *
      * @param responseBody The body of the response
      * @return A string containing the body with line breaks removed
@@ -45,10 +51,38 @@ public class CMCErrorDecoder implements ErrorDecoder {
                 byte[] bodyBytes = Util.toByteArray(inputStream);
                 body = new String(bodyBytes, StandardCharsets.UTF_8).replaceAll("[\\r\\n]", "").trim();
             } catch (IOException e) {
-                log.error("Unable to read response body");
+                log.error("Unable to read response body, error [{}]", e.getMessage());
             }
         }
 
         return body;
+    }
+
+    private CMCRejectedException cmcRejectedException(String responseBody) {
+        CMCRejectedException cmcRejectedException = null;
+
+        if (responseBody != null) {
+            try {
+                ObjectMapper objectMapper = new ObjectMapper();
+                ErrorResponse errorResponse = objectMapper.readValue(responseBody, ErrorResponse.class);
+
+                if (errorResponse.getErrorCode() == null) {
+                    log.error("Response body does not contain expected error code field");
+                } else {
+                    cmcRejectedException =
+                        new CMCRejectedException(errorResponse.getErrorCode(), errorResponse.getErrorText());
+                }
+            } catch (JsonProcessingException e) {
+                log.error("Unable to convert response body to CMCRejectedException, error [{}]", e.getMessage());
+            }
+        }
+
+        return cmcRejectedException;
+    }
+
+    private CMCException createCMCException(int status, String responseBody) {
+        String messageStatusElement = "status: " + status;
+        String messageBodyElement = responseBody.isEmpty() ? "" : ", body: " + responseBody;
+        return new CMCException(messageStatusElement + messageBodyElement);
     }
 }

--- a/consumers/src/main/java/uk/gov/moj/sdt/cmc/consumers/exception/CMCRejectedException.java
+++ b/consumers/src/main/java/uk/gov/moj/sdt/cmc/consumers/exception/CMCRejectedException.java
@@ -1,0 +1,27 @@
+package uk.gov.moj.sdt.cmc.consumers.exception;
+
+import lombok.Getter;
+
+import java.io.Serial;
+
+public class CMCRejectedException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 6125751945448516793L;
+
+    private final int errorCode;
+
+    @Getter
+    private final String errorText;
+
+    public CMCRejectedException(int errorCode, String errorText) {
+        super();
+
+        this.errorCode = errorCode;
+        this.errorText = errorText;
+    }
+
+    public String getErrorCode() {
+        return String.valueOf(errorCode);
+    }
+}

--- a/consumers/src/main/java/uk/gov/moj/sdt/cmc/consumers/response/ErrorResponse.java
+++ b/consumers/src/main/java/uk/gov/moj/sdt/cmc/consumers/response/ErrorResponse.java
@@ -1,0 +1,15 @@
+package uk.gov.moj.sdt.cmc.consumers.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ErrorResponse {
+
+    private Integer errorCode;
+
+    private String errorText;
+}

--- a/consumers/src/unit-test/java/uk/gov/moj/sdt/cmc/consumers/decoder/CMCErrorDecoderTest.java
+++ b/consumers/src/unit-test/java/uk/gov/moj/sdt/cmc/consumers/decoder/CMCErrorDecoderTest.java
@@ -3,7 +3,10 @@ package uk.gov.moj.sdt.cmc.consumers.decoder;
 import feign.Request;
 import feign.Response;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import uk.gov.moj.sdt.cmc.consumers.exception.CMCCaseLockedException;
+import uk.gov.moj.sdt.cmc.consumers.exception.CMCRejectedException;
 import uk.gov.moj.sdt.utils.AbstractSdtUnitTestBase;
 import uk.gov.moj.sdt.utils.cmc.exception.CMCException;
 
@@ -20,10 +23,12 @@ class CMCErrorDecoderTest extends AbstractSdtUnitTestBase {
     private static final String METHOD_KEY = "testMethodKey";
     private static final String REQUEST_URL = "testUrl";
 
+    private static final int STATUS_BAD_REQUEST = 400;
     private static final int STATUS_NOT_FOUND = 404;
     private static final int STATUS_CASE_LOCKED = 423;
     private static final int STATUS_INTERNAL_SERVER_ERROR = 500;
 
+    private static final String ERROR_UNEXPECTED_MESSAGE = "Exception has unexpected message";
     private static final String ERROR_UNEXPECTED_EXCEPTION = "Error decoder returned an unexpected exception";
 
     private CMCErrorDecoder cmcErrorDecoder;
@@ -31,6 +36,35 @@ class CMCErrorDecoderTest extends AbstractSdtUnitTestBase {
     @Override
     protected void setUpLocalTests() {
         cmcErrorDecoder = new CMCErrorDecoder();
+    }
+
+    @Test
+    void testDecodeRejectedException() {
+        String responseBody = "{\"errorCode\":72,\"errorText\":\"Paid in full date missing\"}";
+        Response response = createResponseWithBody(STATUS_BAD_REQUEST, responseBody);
+
+        Exception exception = cmcErrorDecoder.decode(METHOD_KEY, response);
+
+        assertInstanceOf(CMCRejectedException.class, exception, ERROR_UNEXPECTED_EXCEPTION);
+
+        CMCRejectedException cmcRejectedException = (CMCRejectedException) exception;
+        assertEquals("72", cmcRejectedException.getErrorCode(), "Exception has unexpected error code");
+        assertEquals("Paid in full date missing",
+                     cmcRejectedException.getErrorText(),
+                     "Exception has unexpected error text");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"Bad Request", "{\"error\":\"Bad Request\"}"})
+    void testDecodeRejectedExceptionNonErrorResponseBody(String responseBody) {
+        Response response = createResponseWithBody(STATUS_BAD_REQUEST, responseBody);
+
+        Exception exception = cmcErrorDecoder.decode(METHOD_KEY, response);
+
+        assertInstanceOf(CMCException.class, exception, ERROR_UNEXPECTED_EXCEPTION);
+
+        String expectedMessage = "status: 400, body: " + responseBody;
+        assertEquals(expectedMessage, exception.getMessage(), ERROR_UNEXPECTED_MESSAGE);
     }
 
     @Test
@@ -51,8 +85,8 @@ class CMCErrorDecoderTest extends AbstractSdtUnitTestBase {
 
         assertInstanceOf(CMCException.class, exception, ERROR_UNEXPECTED_EXCEPTION);
 
-        String expectedResponseBody = "status: 404, body: " + responseBody;
-        assertEquals(expectedResponseBody, exception.getMessage(), "CMCException has unexpected message");
+        String expectedMessage = "status: 404, body: " + responseBody;
+        assertEquals(expectedMessage, exception.getMessage(), ERROR_UNEXPECTED_MESSAGE);
     }
 
     @Test
@@ -62,7 +96,7 @@ class CMCErrorDecoderTest extends AbstractSdtUnitTestBase {
         Exception exception = cmcErrorDecoder.decode(METHOD_KEY, response);
 
         assertInstanceOf(CMCException.class, exception, ERROR_UNEXPECTED_EXCEPTION);
-        assertEquals("status: 500", exception.getMessage(), "CMCException has unexpected message");
+        assertEquals("status: 500", exception.getMessage(), ERROR_UNEXPECTED_MESSAGE);
     }
 
     private Response createResponse(int status) {

--- a/consumers/src/unit-test/java/uk/gov/moj/sdt/cmc/consumers/response/ErrorResponseTest.java
+++ b/consumers/src/unit-test/java/uk/gov/moj/sdt/cmc/consumers/response/ErrorResponseTest.java
@@ -1,0 +1,25 @@
+package uk.gov.moj.sdt.cmc.consumers.response;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ErrorResponseTest extends ResponseTestBase {
+
+    @Test
+    void convertToObject() throws JsonProcessingException {
+        String responseJson = """
+            {
+              "errorCode" : 23,
+              "errorText" : "Specified claim does not belong to the requesting customer"
+            }""";
+
+        ErrorResponse errorResponse = objectMapper.readValue(responseJson, ErrorResponse.class);
+
+        assertEquals(23, errorResponse.getErrorCode(), "Error response has unexpected error code");
+        assertEquals("Specified claim does not belong to the requesting customer",
+                     errorResponse.getErrorText(),
+                     "Error response has unexpected error text");
+    }
+}

--- a/services/src/main/java/uk/gov/moj/sdt/services/AbstractSdtService.java
+++ b/services/src/main/java/uk/gov/moj/sdt/services/AbstractSdtService.java
@@ -128,7 +128,6 @@ public abstract class AbstractSdtService {
 
         final List<String> completeRequestStatus = Arrays.asList(ACCEPTED.getStatus(), REJECTED.getStatus());
 
-
         final long requestsCount = this.getIndividualRequestDao().queryAsCount(
             IndividualRequest.class,
             () -> createCriteria(


### PR DESCRIPTION
### JIRA link (if applicable) ###
SDT-203 (https://tools.hmcts.net/jira/browse/SDT-203)


### Change description ###
- Added ErrorResponse class for converting body of bad request errors received from CMC.
- Added CMCRejectedException class.
- Updated CMCErrorDecoder to catch bad request errors and convert them to CMCRejectedExceptions via ErrorResponse objects.  If error has an unexpected body then a CMCException is raised instead.
- Updated CMCConsumerGateway to catch and handle CMCRejectedExceptions.  Removed case offline error handling code from exception catch block as this is now a CMCRejectedException.
- Updated CMCConsumerGateway to add a catch block to rethrow CMCExceptions returned by CMCErrorDecoder.
- Updated CMCConsumerGateway RetryableException catch block to throw a CMCException for non-timeout exceptions.
- Updated TargetApplicationSubmissionService.processRequestToSubmit() method to handle CMCUnsupportedRequestTypeExceptions.  Also changed CMCException catch block to handle CMCExceptions as internal errors.
- Completed unfinished javadoc comments in TargetApplicationSubmissionService class and removed some whitespace.
- Updated existing tests and added new tests.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
