### PR TITLE
SDT-236: Update azurerm to version 4 (demo)

### DIFF
--- a/infrastructure/app-insights.tf
+++ b/infrastructure/app-insights.tf
@@ -1,5 +1,5 @@
 module "application_insights" {
-  source = "git@github.com:hmcts/terraform-module-application-insights?ref=main"
+  source = "git@github.com:hmcts/terraform-module-application-insights?ref=4.x"
 
   env                 = var.env
   product             = var.product

--- a/infrastructure/service-bus.tf
+++ b/infrastructure/service-bus.tf
@@ -2,7 +2,7 @@ module "servicebus-namespace" {
   providers = {
     azurerm.private_endpoint = azurerm.private_endpoint
   }
-  source              = "git@github.com:hmcts/terraform-module-servicebus-namespace?ref=master"
+  source              = "git@github.com:hmcts/terraform-module-servicebus-namespace?ref=4.x"
   name                = "${var.product}-${var.component}-servicebus-${var.env}"
   resource_group_name = azurerm_resource_group.civil_sdt_rg.name
   location            = var.location
@@ -13,7 +13,7 @@ module "servicebus-namespace" {
 }
 
 module "servicebus-sdt-queue" {
-  source                        = "git@github.com:hmcts/terraform-module-servicebus-queue?ref=master"
+  source                        = "git@github.com:hmcts/terraform-module-servicebus-queue?ref=4.x"
   name                          = "${var.product}-${var.component}-in-out-${var.env}"
   namespace_name                = module.servicebus-namespace.name
   resource_group_name           = azurerm_resource_group.civil_sdt_rg.name

--- a/infrastructure/service-bus.tf
+++ b/infrastructure/service-bus.tf
@@ -9,7 +9,6 @@ module "servicebus-namespace" {
   env                 = var.env
   common_tags         = local.tags
   sku                 = var.sku
-  zone_redundant      = (var.sku != "Premium" ? "false" : "true")
 }
 
 module "servicebus-sdt-queue" {

--- a/infrastructure/state.tf
+++ b/infrastructure/state.tf
@@ -4,9 +4,9 @@ provider "azurerm" {
 
 provider "azurerm" {
   features {}
-  skip_provider_registration = true
-  alias                      = "private_endpoint"
-  subscription_id            = var.aks_subscription_id
+  resource_provider_registrations = "none"
+  alias                           = "private_endpoint"
+  subscription_id                 = var.aks_subscription_id
 }
 
 terraform {
@@ -17,7 +17,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.117.0" # AzureRM provider version
+      version = "~> 4.0" # AzureRM provider version
     }
   }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
SDT-236 (https://tools.hmcts.net/jira/browse/SDT-236)


### Change description ###
state.tf
- Changed azurerm skip_provider_registration argument to resource_provider_registrations.  This is to resolve a deprecation warning.
- Changed azurerm required_providers version to "~> 4.0"

app-insights.tf
- Changed application_insights module to reference 4.x branch of terraform-module-application-insights

service-bus.tf
- Changed servicebus-namespace module to reference 4.x branch of terraform-module-servicebus-namespace
- Changed servicebus-sdt-queue module to reference 4.x branch of terraform-module-servicebus-queue
- Removed zone_redundant argument from servicebus-namespace module.  Argument was marked as deprecated in azurerm version 3 and has been removed in azurerm version 4.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
