### PR TITLE
SDT-256: Set key vault properties for reporting on DB infrastructure

### DIFF
--- a/infrastructure/database.tf
+++ b/infrastructure/database.tf
@@ -21,7 +21,7 @@ module "postgresql-v15" {
     }
   ]
   kv_name                            = module.civil_sdt_key_vault.key_vault_name
-  kv_subscription                    = var.aks_subscription_id
+  kv_subscription                    = var.kv_subscription
   user_secret_name                   = azurerm_key_vault_secret.POSTGRES-USER-V15.name
   pass_secret_name                   = azurerm_key_vault_secret.POSTGRES-PASS-V15.name
   force_db_report_privileges_trigger = "1"

--- a/infrastructure/prod.tfvars
+++ b/infrastructure/prod.tfvars
@@ -1,0 +1,1 @@
+kv_subscription = "DCD-CNP-Prod"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -60,3 +60,8 @@ variable "max_message_size_in_kilobytes" {
   default     = null
 }
 
+variable "kv_subscription" {
+  type        = string
+  description = "Name or Id of key vault subscription.  Used for setting up privileges for database reporting postgres cron jobs.  Only applies to production."
+  default     = "DCD-CNP-DEV"
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
SDT-256 (https://tools.hmcts.net/jira/browse/SDT-256)


### Change description ###
Set the key vault properties for terraform-module-postgresql-flexible so that module can correctly identify key vault and secrets needed for reporting DB permissions script.  These are needed as civil-sdt does not use the default values that terraform-module-postgresql-flexible assumes a project will use.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
