### PR TITLE
Configure Renovate schedule civil-sdt

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,7 +4,7 @@
     "local>hmcts/.github:renovate-config",
     "local>hmcts/.github//renovate/automerge-minor"
   ],
-  "schedule": ["* 8-19 * * 1-5"],
-  "automergeSchedule": ["* 8-19 * * 1-5"],
+  "schedule": ["* 8-18 * * 1-5"],
+  "automergeSchedule": ["* 8-18 * * 1-5"],
   "updateNotScheduled": false
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
(https://tools.hmcts.net/jira/browse/SDT-266)


### Change description ###
Configure Renovate to only create, update and merge dependency updates between 08:00 and 18:00, Monday to Friday. This will prevent Renovate from attempting to make changes when the non-production environments are not available.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
