### PR TITLE
SDT-392 - Added new CVEs to suppressions.xml

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -51,6 +51,9 @@
       CVE-2026-40974
       CVE-2026-40975
       CVE-2026-40977
+      CVE-2026-40988
+      CVE-2026-41003
+      CVE-2026-41694
       CVE-2026-41838
       CVE-2026-41840
       CVE-2026-41841
@@ -69,9 +72,35 @@
       CVE-2026-42402
       CVE-2026-42403
       CVE-2026-42404
+      CVE-2026-44249
+      CVE-2026-44250
       CVE-2026-44417
       CVE-2026-44618
+      CVE-2026-44890
+      CVE-2026-44893
       CVE-2026-44930
+      CVE-2026-45416
+      CVE-2026-45536
+      CVE-2026-45673
+      CVE-2026-45674
+      CVE-2026-46340
+      CVE-2026-47244
+      CVE-2026-47691
+      CVE-2026-48006
+      CVE-2026-48043
+      CVE-2026-48059
+      CVE-2026-50010
+      CVE-2026-50011
+      CVE-2026-50020
+      CVE-2026-50560
+      CVE-2026-50623
+      CVE-2026-50629
+      CVE-2026-50630
+      CVE-2026-50631
+      CVE-2026-50632
+      CVE-2026-50633
+      CVE-2026-50634
+      CVE-2026-50645
     </notes>
     <cve>CVE-2023-1932</cve>
     <cve>CVE-2024-6763</cve>
@@ -103,6 +132,9 @@
     <cve>CVE-2026-40974</cve>
     <cve>CVE-2026-40975</cve>
     <cve>CVE-2026-40977</cve>
+    <cve>CVE-2026-40988</cve>
+    <cve>CVE-2026-41003</cve>
+    <cve>CVE-2026-41694</cve>
     <cve>CVE-2026-41838</cve>
     <cve>CVE-2026-41840</cve>
     <cve>CVE-2026-41841</cve>
@@ -121,9 +153,35 @@
     <cve>CVE-2026-42402</cve>
     <cve>CVE-2026-42403</cve>
     <cve>CVE-2026-42404</cve>
+    <cve>CVE-2026-44249</cve>
+    <cve>CVE-2026-44250</cve>
     <cve>CVE-2026-44417</cve>
     <cve>CVE-2026-44618</cve>
-    <cve>CVE-2026-44930</cve>    
+    <cve>CVE-2026-44890</cve>
+    <cve>CVE-2026-44893</cve>
+    <cve>CVE-2026-44930</cve>
+    <cve>CVE-2026-45416</cve>
+    <cve>CVE-2026-45536</cve>
+    <cve>CVE-2026-45673</cve>
+    <cve>CVE-2026-45674</cve>
+    <cve>CVE-2026-46340</cve>
+    <cve>CVE-2026-47244</cve>
+    <cve>CVE-2026-47691</cve>
+    <cve>CVE-2026-48006</cve>
+    <cve>CVE-2026-48043</cve>
+    <cve>CVE-2026-48059</cve>
+    <cve>CVE-2026-50010</cve>
+    <cve>CVE-2026-50011</cve>
+    <cve>CVE-2026-50020</cve>
+    <cve>CVE-2026-50560</cve>
+    <cve>CVE-2026-50623</cve>
+    <cve>CVE-2026-50629</cve>
+    <cve>CVE-2026-50630</cve>
+    <cve>CVE-2026-50631</cve>
+    <cve>CVE-2026-50632</cve>
+    <cve>CVE-2026-50633</cve>
+    <cve>CVE-2026-50634</cve>
+    <cve>CVE-2026-50645</cve>
   </suppress>
   <!--End of temporary suppression section -->
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SDT-392


### Change description ###
The following CVEs need to be added to the suppressions list: 
- CVE-2026-40988
- CVE-2026-41003
- CVE-2026-41694
- CVE-2026-44249
- CVE-2026-44250
- CVE-2026-44890
- CVE-2026-44893
- CVE-2026-45416
- CVE-2026-45536
- CVE-2026-45673
- CVE-2026-45674
- CVE-2026-46340
- CVE-2026-47244
- CVE-2026-47691
- CVE-2026-48006
- CVE-2026-48043
- CVE-2026-48059
- CVE-2026-50010
- CVE-2026-50011
- CVE-2026-50020
- CVE-2026-50560
- CVE-2026-50623
- CVE-2026-50629
- CVE-2026-50630
- CVE-2026-50631
- CVE-2026-50632
- CVE-2026-50633
- CVE-2026-50634
- CVE-2026-50645


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
